### PR TITLE
Fix using a deprecated method & ignoring pre-v6 seats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reduced the `wl_seat` version requirement from 6 to 2.
+
 ## v0.3.0 (4th Apr 2019)
 
 - **Breaking** Moved `ClipboardType` into `copy::` and `paste::`.

--- a/src/common.rs
+++ b/src/common.rs
@@ -40,7 +40,7 @@ pub fn initialize(primary: bool, socket_name: Option<OsString>) -> Result<Common
     let seats_2 = seats.clone();
     let global_manager =
         GlobalManager::new_with_cb(&display,
-                                   global_filter!([WlSeat, 6, move |seat: NewProxy<WlSeat>| {
+                                   global_filter!([WlSeat, 2, move |seat: NewProxy<WlSeat>| {
                                                       let seat_data =
                                                           RefCell::new(SeatData::default());
                                                       let seat =

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -115,6 +115,33 @@ fn is_primary_selection_supported_no_seats() {
 }
 
 #[test]
+fn supports_v2_seats() {
+    let mut server = TestServer::new();
+    server.display
+          .create_global::<ServerSeat, _>(2, |new_res, _| {
+              new_res.implement_dummy();
+          });
+    server.display
+          .create_global::<ServerManager, _>(2, |new_res, _| {
+              new_res.implement_dummy();
+          });
+
+    let socket_name = mem::replace(&mut server.socket_name, OsString::new());
+    let child = thread::spawn(move || is_primary_selection_supported_internal(Some(socket_name)));
+
+    thread::sleep(Duration::from_millis(100));
+    server.answer();
+
+    thread::sleep(Duration::from_millis(100));
+    server.answer();
+
+    let res = child.join().unwrap();
+    if let Err(PrimarySelectionCheckError::NoSeats) = res {
+        panic!("Invalid error: {:?}", res);
+    }
+}
+
+#[test]
 fn is_primary_selection_supported_no_data_control() {
     let mut server = TestServer::new();
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -247,7 +247,7 @@ pub(crate) fn is_primary_selection_supported_internal(
     let seats_2 = seats.clone();
     let global_manager =
         GlobalManager::new_with_cb(&display,
-                                   global_filter!([WlSeat, 6, move |seat: NewProxy<WlSeat>| {
+                                   global_filter!([WlSeat, 2, move |seat: NewProxy<WlSeat>| {
                                                       let seat_data =
                                                           RefCell::new(SeatData::default());
                                                       let seat =


### PR DESCRIPTION
With these, wl-clipboard-rs works under my Mutter fork with wlr-data-control support.