### PR TITLE
Remove failure dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ members = [".", "wl-clipboard-tools"]
 [dependencies]
 derive-new = "0.5.9"
 derive_more = "0.99.17"
-failure = "0.1.8"
 libc = "0.2.119"
 log = "0.4.14"
 nix = "0.23.1"

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,5 @@
 use std::{cell::RefCell, ffi::OsString, io, rc::Rc};
 
-use failure::Fail;
 use wayland_client::{
     global_filter, protocol::wl_seat::WlSeat, ConnectError, Display, EventQueue, GlobalManager, Interface, Main,
 };
@@ -14,16 +13,17 @@ pub struct CommonData {
     pub seats: Rc<RefCell<Vec<Main<WlSeat>>>>,
 }
 
-#[derive(Fail, Debug)]
+#[derive(derive_more::Error, derive_more::Display, Debug)]
 pub enum Error {
-    #[fail(display = "Couldn't connect to the Wayland compositor")]
-    WaylandConnection(#[cause] ConnectError),
+    #[display(fmt = "Couldn't connect to the Wayland compositor")]
+    WaylandConnection(#[error(source)] ConnectError),
 
-    #[fail(display = "Wayland compositor communication error")]
-    WaylandCommunication(#[cause] io::Error),
+    #[display(fmt = "Wayland compositor communication error")]
+    WaylandCommunication(#[error(source)] io::Error),
 
-    #[fail(display = "A required Wayland protocol ({} version {}) is not supported by the compositor",
-           name, version)]
+    #[display(fmt = "A required Wayland protocol ({} version {}) is not supported by the compositor",
+              name,
+              version)]
     MissingProtocol { name: &'static str, version: u32 },
 }
 

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -14,7 +14,6 @@ use std::{
     thread,
 };
 
-use failure::Fail;
 use log::info;
 use wayland_client::{ConnectError, EventQueue, Main, Proxy};
 use wayland_protocols::wlr::unstable::data_control::v1::client::{
@@ -155,69 +154,70 @@ pub struct PreparedCopy {
 }
 
 /// Errors that can occur for copying the source data to a temporary file.
-#[derive(Fail, Debug)]
+#[derive(derive_more::Error, derive_more::Display, Debug)]
 pub enum SourceCreationError {
-    #[fail(display = "Couldn't create a temporary directory")]
-    TempDirCreate(#[cause] io::Error),
+    #[display(fmt = "Couldn't create a temporary directory")]
+    TempDirCreate(#[error(source)] io::Error),
 
-    #[fail(display = "Couldn't create a temporary file")]
-    TempFileCreate(#[cause] io::Error),
+    #[display(fmt = "Couldn't create a temporary file")]
+    TempFileCreate(#[error(source)] io::Error),
 
-    #[fail(display = "Couldn't copy data to the temporary file")]
-    DataCopy(#[cause] utils::CopyDataError),
+    #[display(fmt = "Couldn't copy data to the temporary file")]
+    DataCopy(#[error(source)] utils::CopyDataError),
 
-    #[fail(display = "Couldn't write to the temporary file")]
-    TempFileWrite(#[cause] io::Error),
+    #[display(fmt = "Couldn't write to the temporary file")]
+    TempFileWrite(#[error(source)] io::Error),
 
-    #[fail(display = "Couldn't open the temporary file for newline trimming")]
-    TempFileOpen(#[cause] io::Error),
+    #[display(fmt = "Couldn't open the temporary file for newline trimming")]
+    TempFileOpen(#[error(source)] io::Error),
 
-    #[fail(display = "Couldn't get the temporary file metadata for newline trimming")]
-    TempFileMetadata(#[cause] io::Error),
+    #[display(fmt = "Couldn't get the temporary file metadata for newline trimming")]
+    TempFileMetadata(#[error(source)] io::Error),
 
-    #[fail(display = "Couldn't seek the temporary file for newline trimming")]
-    TempFileSeek(#[cause] io::Error),
+    #[display(fmt = "Couldn't seek the temporary file for newline trimming")]
+    TempFileSeek(#[error(source)] io::Error),
 
-    #[fail(display = "Couldn't read the last byte of the temporary file for newline trimming")]
-    TempFileRead(#[cause] io::Error),
+    #[display(fmt = "Couldn't read the last byte of the temporary file for newline trimming")]
+    TempFileRead(#[error(source)] io::Error),
 
-    #[fail(display = "Couldn't truncate the temporary file for newline trimming")]
-    TempFileTruncate(#[cause] io::Error),
+    #[display(fmt = "Couldn't truncate the temporary file for newline trimming")]
+    TempFileTruncate(#[error(source)] io::Error),
 }
 
 /// Errors that can occur for copying and clearing the clipboard.
-#[derive(Fail, Debug)]
+#[derive(derive_more::Error, derive_more::Display, Debug)]
 pub enum Error {
-    #[fail(display = "There are no seats")]
+    #[display(fmt = "There are no seats")]
     NoSeats,
 
-    #[fail(display = "Couldn't connect to the Wayland compositor")]
-    WaylandConnection(#[cause] ConnectError),
+    #[display(fmt = "Couldn't connect to the Wayland compositor")]
+    WaylandConnection(#[error(source)] ConnectError),
 
-    #[fail(display = "Wayland compositor communication error")]
-    WaylandCommunication(#[cause] io::Error),
+    #[display(fmt = "Wayland compositor communication error")]
+    WaylandCommunication(#[error(source)] io::Error),
 
-    #[fail(display = "A required Wayland protocol ({} version {}) is not supported by the compositor",
-           name, version)]
+    #[display(fmt = "A required Wayland protocol ({} version {}) is not supported by the compositor",
+              name,
+              version)]
     MissingProtocol { name: &'static str, version: u32 },
 
-    #[fail(display = "The compositor does not support primary selection")]
+    #[display(fmt = "The compositor does not support primary selection")]
     PrimarySelectionUnsupported,
 
-    #[fail(display = "The requested seat was not found")]
+    #[display(fmt = "The requested seat was not found")]
     SeatNotFound,
 
-    #[fail(display = "Error copying the source into a temporary file")]
-    TempCopy(#[cause] SourceCreationError),
+    #[display(fmt = "Error copying the source into a temporary file")]
+    TempCopy(#[error(source)] SourceCreationError),
 
-    #[fail(display = "Couldn't remove the temporary file")]
-    TempFileRemove(#[cause] io::Error),
+    #[display(fmt = "Couldn't remove the temporary file")]
+    TempFileRemove(#[error(source)] io::Error),
 
-    #[fail(display = "Couldn't remove the temporary directory")]
-    TempDirRemove(#[cause] io::Error),
+    #[display(fmt = "Couldn't remove the temporary directory")]
+    TempDirRemove(#[error(source)] io::Error),
 
-    #[fail(display = "Error satisfying a paste request")]
-    Paste(#[cause] DataSourceError),
+    #[display(fmt = "Error satisfying a paste request")]
+    Paste(#[error(source)] DataSourceError),
 }
 
 impl From<common::Error> for Error {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use derive_new::new;
-use failure::Fail;
 use nix::unistd::close;
 use wayland_client::{
     protocol::{wl_seat::WlSeat, *},
@@ -98,13 +97,13 @@ fn data_offer_handler(offer: Main<ZwlrDataControlOfferV1>, event: zwlr_data_cont
     }
 }
 
-#[derive(Fail, Debug)]
+#[derive(derive_more::Error, derive_more::Display, Debug)]
 pub enum DataSourceError {
-    #[fail(display = "Couldn't open the data file")]
-    FileOpen(#[cause] io::Error),
+    #[display(fmt = "Couldn't open the data file")]
+    FileOpen(#[error(source)] io::Error),
 
-    #[fail(display = "Couldn't copy the data to the target file descriptor")]
-    Copy(#[cause] utils::CopyDataError),
+    #[display(fmt = "Couldn't copy the data to the target file descriptor")]
+    Copy(#[error(source)] utils::CopyDataError),
 }
 
 #[derive(new)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,7 @@
 //! Copying to the regular clipboard:
 //! ```no_run
 //! # extern crate wl_clipboard_rs;
-//! # use wl_clipboard_rs::copy::Error;
-//! # fn foo() -> Result<(), Error> {
+//! # fn foo() -> Result<(), Box<dyn std::error::Error>> {
 //! use wl_clipboard_rs::copy::{MimeType, Options, Source};
 //!
 //! let opts = Options::new();
@@ -42,9 +41,7 @@
 //! Pasting plain text from the regular clipboard:
 //! ```no_run
 //! # extern crate wl_clipboard_rs;
-//! # extern crate failure;
-//! # use failure::Error;
-//! # fn foo() -> Result<(), Error> {
+//! # fn foo() -> Result<(), Box<dyn std::error::Error>> {
 //! use std::io::Read;
 //! use wl_clipboard_rs::{paste::{get_contents, ClipboardType, Error, MimeType, Seat}};
 //!
@@ -72,9 +69,7 @@
 //!
 //! ```no_run
 //! # extern crate wl_clipboard_rs;
-//! # extern crate failure;
-//! # use failure::Error;
-//! # fn foo() -> Result<(), Error> {
+//! # fn foo() -> Result<(), Box<dyn std::error::Error>> {
 //! use wl_clipboard_rs::utils::{is_primary_selection_supported, PrimarySelectionCheckError};
 //!
 //! match is_primary_selection_supported() {

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -9,7 +9,6 @@ use std::{
     rc::Rc,
 };
 
-use failure::Fail;
 use os_pipe::{pipe, PipeReader};
 use wayland_client::{ConnectError, EventQueue};
 use wayland_protocols::wlr::unstable::data_control::v1::client::zwlr_data_control_offer_v1::ZwlrDataControlOfferV1;
@@ -86,35 +85,36 @@ impl Default for Seat<'_> {
 /// You may want to ignore some of these errors (rather than show an error message), like
 /// `NoSeats`, `ClipboardEmpty` or `NoMimeType` as they are essentially equivalent to an empty
 /// clipboard.
-#[derive(Fail, Debug)]
+#[derive(derive_more::Error, derive_more::Display, Debug)]
 pub enum Error {
-    #[fail(display = "There are no seats")]
+    #[display(fmt = "There are no seats")]
     NoSeats,
 
-    #[fail(display = "The clipboard of the requested seat is empty")]
+    #[display(fmt = "The clipboard of the requested seat is empty")]
     ClipboardEmpty,
 
-    #[fail(display = "No suitable type of content copied")]
+    #[display(fmt = "No suitable type of content copied")]
     NoMimeType,
 
-    #[fail(display = "Couldn't connect to the Wayland compositor")]
-    WaylandConnection(#[cause] ConnectError),
+    #[display(fmt = "Couldn't connect to the Wayland compositor")]
+    WaylandConnection(#[error(source)] ConnectError),
 
-    #[fail(display = "Wayland compositor communication error")]
-    WaylandCommunication(#[cause] io::Error),
+    #[display(fmt = "Wayland compositor communication error")]
+    WaylandCommunication(#[error(source)] io::Error),
 
-    #[fail(display = "A required Wayland protocol ({} version {}) is not supported by the compositor",
-           name, version)]
+    #[display(fmt = "A required Wayland protocol ({} version {}) is not supported by the compositor",
+              name,
+              version)]
     MissingProtocol { name: &'static str, version: u32 },
 
-    #[fail(display = "The compositor does not support primary selection")]
+    #[display(fmt = "The compositor does not support primary selection")]
     PrimarySelectionUnsupported,
 
-    #[fail(display = "The requested seat was not found")]
+    #[display(fmt = "The requested seat was not found")]
     SeatNotFound,
 
-    #[fail(display = "Couldn't create a pipe for content transfer")]
-    PipeCreation(#[cause] io::Error),
+    #[display(fmt = "Couldn't create a pipe for content transfer")]
+    PipeCreation(#[error(source)] io::Error),
 }
 
 impl From<common::Error> for Error {
@@ -247,9 +247,7 @@ pub(crate) fn get_mime_types_internal(clipboard: ClipboardType,
 ///
 /// ```no_run
 /// # extern crate wl_clipboard_rs;
-/// # extern crate failure;
-/// # use failure::Error;
-/// # fn foo() -> Result<(), Error> {
+/// # fn foo() -> Result<(), Box<dyn std::error::Error>> {
 /// use std::io::Read;
 /// use wl_clipboard_rs::{paste::{get_contents, ClipboardType, Error, MimeType, Seat}};
 ///

--- a/wl-clipboard-tools/Cargo.toml
+++ b/wl-clipboard-tools/Cargo.toml
@@ -5,8 +5,7 @@ edition = "2018"
 
 [dependencies]
 wl-clipboard-rs = { path = "../" }
-exitfailure = "0.5"
-failure = "0.1"
+anyhow = "1.0.56"
 libc = "0.2"
 log = "0.4"
 mime_guess = "2"

--- a/wl-clipboard-tools/src/bin/wl_copy.rs
+++ b/wl-clipboard-tools/src/bin/wl_copy.rs
@@ -2,7 +2,6 @@
 
 use std::{ffi::OsString, os::unix::ffi::OsStringExt};
 
-use exitfailure::ExitFailure;
 use nix::unistd::{fork, ForkResult};
 use structopt::{clap::AppSettings, StructOpt};
 
@@ -96,7 +95,7 @@ impl From<Options> for copy::Options {
     }
 }
 
-fn main() -> Result<(), ExitFailure> {
+fn main() -> Result<(), anyhow::Error> {
     // Parse command-line options.
     let mut options = Options::from_args();
 

--- a/wl-clipboard-tools/src/bin/wl_paste.rs
+++ b/wl-clipboard-tools/src/bin/wl_paste.rs
@@ -5,8 +5,7 @@ use std::{
     io::{stdout, Read, Write},
 };
 
-use exitfailure::ExitFailure;
-use failure::ResultExt;
+use anyhow::Context;
 use libc::STDOUT_FILENO;
 use log::info;
 use mime_guess::Mime;
@@ -64,7 +63,7 @@ fn infer_mime_type() -> Option<Mime> {
     }
 }
 
-fn main() -> Result<(), ExitFailure> {
+fn main() -> Result<(), anyhow::Error> {
     // Parse command-line options.
     let options = Options::from_args();
     let primary = if options.primary {


### PR DESCRIPTION
The crate is deprecated and abandoned. It suggests using `thiserror` as a
replacement for the derive macros, but we already have `derive_more` which
can do the same, so use that instead. This very likely is an API breaking
change.

------

I apologize for making this change right after a new version was released. I should have payed more attention and made this PR *before* asking for a release.
