### PR TITLE
Cargo.toml: fix feature native_lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,11 @@ os_pipe = "1.0.1"
 tempfile = "3.3.0"
 tree_magic_mini = "3.0.3"
 wayland-client = "0.29.4"
+wayland-server = "0.29.4"
 
 [dependencies.wayland-protocols]
 version = "0.29.4"
 features = ["client", "unstable_protocols"]
-
-[dev-dependencies]
-wayland-server = "0.29.4"
 
 [dev-dependencies.wayland-protocols]
 version = "0.29.4"


### PR DESCRIPTION
The problem was that the feature enabled a feature in wayland-server, although wayland-server was only available as a dev-dependeny. The most simple way to fix this is to just put wayland-server in the normal dependencies.