### PR TITLE
Replace `derive_more` with `thiserror`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ members = [".", "wl-clipboard-rs-tools"]
 
 [dependencies]
 derive-new = "0.5.9"
-derive_more = "0.99.17"
 libc = "0.2.119"
 log = "0.4.14"
 nix = "0.23.1"
 os_pipe = "1.0.1"
 tempfile = "3.3.0"
+thiserror = "1"
 tree_magic_mini = "3.0.3"
 wayland-client = "0.29.4"
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -13,17 +13,15 @@ pub struct CommonData {
     pub seats: Rc<RefCell<Vec<Main<WlSeat>>>>,
 }
 
-#[derive(derive_more::Error, derive_more::Display, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[display(fmt = "Couldn't connect to the Wayland compositor")]
-    WaylandConnection(#[error(source)] ConnectError),
+    #[error("Couldn't connect to the Wayland compositor")]
+    WaylandConnection(#[source] ConnectError),
 
-    #[display(fmt = "Wayland compositor communication error")]
-    WaylandCommunication(#[error(source)] io::Error),
+    #[error("Wayland compositor communication error")]
+    WaylandCommunication(#[source] io::Error),
 
-    #[display(fmt = "A required Wayland protocol ({} version {}) is not supported by the compositor",
-              name,
-              version)]
+    #[error("A required Wayland protocol ({name} version {version}) is not supported by the compositor")]
     MissingProtocol { name: &'static str, version: u32 },
 }
 

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -154,70 +154,70 @@ pub struct PreparedCopy {
 }
 
 /// Errors that can occur for copying the source data to a temporary file.
-#[derive(derive_more::Error, derive_more::Display, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum SourceCreationError {
-    #[display(fmt = "Couldn't create a temporary directory")]
-    TempDirCreate(#[error(source)] io::Error),
+    #[error("Couldn't create a temporary directory")]
+    TempDirCreate(#[source] io::Error),
 
-    #[display(fmt = "Couldn't create a temporary file")]
-    TempFileCreate(#[error(source)] io::Error),
+    #[error("Couldn't create a temporary file")]
+    TempFileCreate(#[source] io::Error),
 
-    #[display(fmt = "Couldn't copy data to the temporary file")]
-    DataCopy(#[error(source)] utils::CopyDataError),
+    #[error("Couldn't copy data to the temporary file")]
+    DataCopy(#[source] utils::CopyDataError),
 
-    #[display(fmt = "Couldn't write to the temporary file")]
-    TempFileWrite(#[error(source)] io::Error),
+    #[error("Couldn't write to the temporary file")]
+    TempFileWrite(#[source] io::Error),
 
-    #[display(fmt = "Couldn't open the temporary file for newline trimming")]
-    TempFileOpen(#[error(source)] io::Error),
+    #[error("Couldn't open the temporary file for newline trimming")]
+    TempFileOpen(#[source] io::Error),
 
-    #[display(fmt = "Couldn't get the temporary file metadata for newline trimming")]
-    TempFileMetadata(#[error(source)] io::Error),
+    #[error("Couldn't get the temporary file metadata for newline trimming")]
+    TempFileMetadata(#[source] io::Error),
 
-    #[display(fmt = "Couldn't seek the temporary file for newline trimming")]
-    TempFileSeek(#[error(source)] io::Error),
+    #[error("Couldn't seek the temporary file for newline trimming")]
+    TempFileSeek(#[source] io::Error),
 
-    #[display(fmt = "Couldn't read the last byte of the temporary file for newline trimming")]
-    TempFileRead(#[error(source)] io::Error),
+    #[error("Couldn't read the last byte of the temporary file for newline trimming")]
+    TempFileRead(#[source] io::Error),
 
-    #[display(fmt = "Couldn't truncate the temporary file for newline trimming")]
-    TempFileTruncate(#[error(source)] io::Error),
+    #[error("Couldn't truncate the temporary file for newline trimming")]
+    TempFileTruncate(#[source] io::Error),
 }
 
 /// Errors that can occur for copying and clearing the clipboard.
-#[derive(derive_more::Error, derive_more::Display, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[display(fmt = "There are no seats")]
+    #[error("There are no seats")]
     NoSeats,
 
-    #[display(fmt = "Couldn't connect to the Wayland compositor")]
-    WaylandConnection(#[error(source)] ConnectError),
+    #[error("Couldn't connect to the Wayland compositor")]
+    WaylandConnection(#[source] ConnectError),
 
-    #[display(fmt = "Wayland compositor communication error")]
-    WaylandCommunication(#[error(source)] io::Error),
+    #[error("Wayland compositor communication error")]
+    WaylandCommunication(#[source] io::Error),
 
-    #[display(fmt = "A required Wayland protocol ({} version {}) is not supported by the compositor",
-              name,
-              version)]
+    #[error("A required Wayland protocol ({} version {}) is not supported by the compositor",
+            name,
+            version)]
     MissingProtocol { name: &'static str, version: u32 },
 
-    #[display(fmt = "The compositor does not support primary selection")]
+    #[error("The compositor does not support primary selection")]
     PrimarySelectionUnsupported,
 
-    #[display(fmt = "The requested seat was not found")]
+    #[error("The requested seat was not found")]
     SeatNotFound,
 
-    #[display(fmt = "Error copying the source into a temporary file")]
-    TempCopy(#[error(source)] SourceCreationError),
+    #[error("Error copying the source into a temporary file")]
+    TempCopy(#[source] SourceCreationError),
 
-    #[display(fmt = "Couldn't remove the temporary file")]
-    TempFileRemove(#[error(source)] io::Error),
+    #[error("Couldn't remove the temporary file")]
+    TempFileRemove(#[source] io::Error),
 
-    #[display(fmt = "Couldn't remove the temporary directory")]
-    TempDirRemove(#[error(source)] io::Error),
+    #[error("Couldn't remove the temporary directory")]
+    TempDirRemove(#[source] io::Error),
 
-    #[display(fmt = "Error satisfying a paste request")]
-    Paste(#[error(source)] DataSourceError),
+    #[error("Error satisfying a paste request")]
+    Paste(#[source] DataSourceError),
 }
 
 impl From<common::Error> for Error {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -97,13 +97,13 @@ fn data_offer_handler(offer: Main<ZwlrDataControlOfferV1>, event: zwlr_data_cont
     }
 }
 
-#[derive(derive_more::Error, derive_more::Display, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum DataSourceError {
-    #[display(fmt = "Couldn't open the data file")]
-    FileOpen(#[error(source)] io::Error),
+    #[error("Couldn't open the data file")]
+    FileOpen(#[source] io::Error),
 
-    #[display(fmt = "Couldn't copy the data to the target file descriptor")]
-    Copy(#[error(source)] utils::CopyDataError),
+    #[error("Couldn't copy the data to the target file descriptor")]
+    Copy(#[source] utils::CopyDataError),
 }
 
 #[derive(new)]

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -85,36 +85,36 @@ impl Default for Seat<'_> {
 /// You may want to ignore some of these errors (rather than show an error message), like
 /// `NoSeats`, `ClipboardEmpty` or `NoMimeType` as they are essentially equivalent to an empty
 /// clipboard.
-#[derive(derive_more::Error, derive_more::Display, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[display(fmt = "There are no seats")]
+    #[error("There are no seats")]
     NoSeats,
 
-    #[display(fmt = "The clipboard of the requested seat is empty")]
+    #[error("The clipboard of the requested seat is empty")]
     ClipboardEmpty,
 
-    #[display(fmt = "No suitable type of content copied")]
+    #[error("No suitable type of content copied")]
     NoMimeType,
 
-    #[display(fmt = "Couldn't connect to the Wayland compositor")]
-    WaylandConnection(#[error(source)] ConnectError),
+    #[error("Couldn't connect to the Wayland compositor")]
+    WaylandConnection(#[source] ConnectError),
 
-    #[display(fmt = "Wayland compositor communication error")]
-    WaylandCommunication(#[error(source)] io::Error),
+    #[error("Wayland compositor communication error")]
+    WaylandCommunication(#[source] io::Error),
 
-    #[display(fmt = "A required Wayland protocol ({} version {}) is not supported by the compositor",
-              name,
-              version)]
+    #[error("A required Wayland protocol ({} version {}) is not supported by the compositor",
+            name,
+            version)]
     MissingProtocol { name: &'static str, version: u32 },
 
-    #[display(fmt = "The compositor does not support primary selection")]
+    #[error("The compositor does not support primary selection")]
     PrimarySelectionUnsupported,
 
-    #[display(fmt = "The requested seat was not found")]
+    #[error("The requested seat was not found")]
     SeatNotFound,
 
-    #[display(fmt = "Couldn't create a pipe for content transfer")]
-    PipeCreation(#[error(source)] io::Error),
+    #[error("Couldn't create a pipe for content transfer")]
+    PipeCreation(#[source] io::Error),
 }
 
 impl From<common::Error> for Error {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -44,31 +44,31 @@ pub fn is_text(mime_type: &str) -> bool {
 }
 
 /// Errors that can occur in `copy_data()`.
-#[derive(derive_more::Error, derive_more::Display, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum CopyDataError {
-    #[display(fmt = "Couldn't set the source file descriptor flags")]
-    SetSourceFdFlags(#[error(source)] nix::Error),
+    #[error("Couldn't set the source file descriptor flags")]
+    SetSourceFdFlags(#[source] nix::Error),
 
-    #[display(fmt = "Couldn't set the target file descriptor flags")]
-    SetTargetFdFlags(#[error(source)] nix::Error),
+    #[error("Couldn't set the target file descriptor flags")]
+    SetTargetFdFlags(#[source] nix::Error),
 
-    #[display(fmt = "Couldn't fork")]
-    Fork(#[error(source)] nix::Error),
+    #[error("Couldn't fork")]
+    Fork(#[source] nix::Error),
 
-    #[display(fmt = "Couldn't close the source file descriptor")]
-    CloseSourceFd(#[error(source)] nix::Error),
+    #[error("Couldn't close the source file descriptor")]
+    CloseSourceFd(#[source] nix::Error),
 
-    #[display(fmt = "Couldn't close the target file descriptor")]
-    CloseTargetFd(#[error(source)] nix::Error),
+    #[error("Couldn't close the target file descriptor")]
+    CloseTargetFd(#[source] nix::Error),
 
-    #[display(fmt = "Couldn't wait for the child process")]
-    Wait(#[error(source)] nix::Error),
+    #[error("Couldn't wait for the child process")]
+    Wait(#[source] nix::Error),
 
-    #[display(fmt = "Received an unexpected status when waiting for the child process: {:?}", _0)]
-    WaitUnexpected(#[error(ignore)] WaitStatus),
+    #[error("Received an unexpected status when waiting for the child process: {:?}", _0)]
+    WaitUnexpected(WaitStatus),
 
-    #[display(fmt = "The child process exited with a non-zero error code: {}", _0)]
-    ChildError(#[error(ignore)] i32),
+    #[error("The child process exited with a non-zero error code: {}", _0)]
+    ChildError(i32),
 }
 
 /// Copies data from one file to another.
@@ -174,20 +174,20 @@ pub fn copy_data(from_fd: Option<RawFd>, to_fd: RawFd, wait: bool) -> Result<(),
 }
 
 /// Errors that can occur when checking whether the primary selection is supported.
-#[derive(derive_more::Error, derive_more::Display, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum PrimarySelectionCheckError {
-    #[display(fmt = "There are no seats")]
+    #[error("There are no seats")]
     NoSeats,
 
-    #[display(fmt = "Couldn't connect to the Wayland compositor")]
-    WaylandConnection(#[error(source)] ConnectError),
+    #[error("Couldn't connect to the Wayland compositor")]
+    WaylandConnection(#[source] ConnectError),
 
-    #[display(fmt = "Wayland compositor communication error")]
-    WaylandCommunication(#[error(source)] io::Error),
+    #[error("Wayland compositor communication error")]
+    WaylandCommunication(#[source] io::Error),
 
-    #[display(fmt = "A required Wayland protocol ({} version {}) is not supported by the compositor",
-              name,
-              version)]
+    #[error("A required Wayland protocol ({} version {}) is not supported by the compositor",
+            name,
+            version)]
     MissingProtocol { name: &'static str, version: u32 },
 }
 


### PR DESCRIPTION
Commit d9829ccb ("Remove failure dependency") made the case that `thiserror` could be used as a replacement for the `failure` crate just as well, but opted to use `derive_more` as it was "already used" by `wl-clipboard-rs`.  Checking the repo before that commit reveals that this was an unused dependency lingering in `Cargo.toml`, without any other references to `derive_more`.

Furthermore `derive_more` is an extremely heavy crate that is causing a multitude of issues for us ([such as inordinate compile times]) which is why we deter it from our dependency graph altogether.

[such as inordinate compile times]: https://github.com/gfx-rs/rspirv/pull/218#issue-1039357885
