### PR TITLE
Demote debug logs from `info` to `trace`

### DIFF
--- a/src/copy.rs
+++ b/src/copy.rs
@@ -14,7 +14,7 @@ use std::{
     thread,
 };
 
-use log::info;
+use log::trace;
 use wayland_client::{ConnectError, EventQueue, Main, Proxy};
 use wayland_protocols::wlr::unstable::data_control::v1::client::{
     zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, zwlr_data_control_manager_v1::ZwlrDataControlManagerV1,
@@ -450,7 +450,7 @@ fn make_source(source: Source,
     let temp_dir = tempfile::tempdir().map_err(SourceCreationError::TempDirCreate)?;
     let mut temp_filename = temp_dir.into_path();
     temp_filename.push("stdin");
-    info!("Temp filename: {}", temp_filename.to_string_lossy());
+    trace!("Temp filename: {}", temp_filename.to_string_lossy());
     let mut temp_file = File::create(&temp_filename).map_err(SourceCreationError::TempFileCreate)?;
 
     if let Source::Bytes(data) = source {
@@ -472,7 +472,7 @@ fn make_source(source: Source,
         MimeType::Specific(mime_type) => mime_type,
     };
 
-    info!("Base MIME type: {}", mime_type);
+    trace!("Base MIME type: {}", mime_type);
 
     // Trim the trailing newline if needed.
     if trim_newline && is_text(&mime_type) {

--- a/wl-clipboard-rs-tools/src/bin/wl-paste.rs
+++ b/wl-clipboard-rs-tools/src/bin/wl-paste.rs
@@ -7,7 +7,7 @@ use std::{
 
 use anyhow::Context;
 use libc::STDOUT_FILENO;
-use log::info;
+use log::trace;
 use mime_guess::Mime;
 use structopt::{clap::AppSettings, StructOpt};
 use wl_clipboard_rs::{paste::*, utils::is_text};
@@ -103,7 +103,7 @@ fn main() -> Result<(), anyhow::Error> {
         Some(ref mime_type) => MimeType::Specific(mime_type),
         None => {
             let inferred: Option<&str> = inferred.as_ref().map(Mime::as_ref);
-            info!("Inferred MIME type: {:?}", inferred);
+            trace!("Inferred MIME type: {:?}", inferred);
             match inferred {
                 None | Some("application/octet-stream") => MimeType::Any,
                 // If the inferred MIME type is text, make sure we'll fall back to requesting


### PR DESCRIPTION
Info is a tad too verbose for debug log messages; prevent having to filter them out by the end user in a typical `log` setup by turning all debug messages into `trace!` logs.

See also a similar PR for `arboard`, one of the users of `wl-clipboard-rs`: https://github.com/1Password/arboard/pull/80
