### PR TITLE
Make additional text mime types optional

### DIFF
--- a/src/copy.rs
+++ b/src/copy.rs
@@ -762,10 +762,10 @@ fn prepare_copy_internal(options: Options,
         // If the MIME type is text, offer it in some other common formats.
         if let Some(text_data_path) = text_data_path {
             let text_mimes = ["text/plain;charset=utf-8",
-                            "text/plain",
-                            "STRING",
-                            "UTF8_STRING",
-                            "TEXT"];
+                              "text/plain",
+                              "STRING",
+                              "UTF8_STRING",
+                              "TEXT"];
             for &mime_type in &text_mimes {
                 // We don't want to overwrite an explicit mime type, because it might be bound to a
                 // different data_path

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -147,7 +147,7 @@ pub struct Options {
     ///
     /// Omits additionally offered `text/plain;charset=utf-8`, `text/plain`, `STRING`, `UTF8_STRING` and
     /// `TEXT` mime types which are offered by default if at least one text mime type is provided.
-    omit_additional_text_mime_types: bool
+    omit_additional_text_mime_types: bool,
 }
 
 /// A copy operation ready to start serving requests.

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -290,9 +290,6 @@ impl Options {
         self
     }
 
-    /// Omit additional text mime types which are offered by default if at least one text mime type is provided.
-    ///
-    
     /// Sets the flag for omitting additional text mime types which are offered by default if at least one text mime type is provided.
     ///
     /// Omits additionally offered `text/plain;charset=utf-8`, `text/plain`, `STRING`, `UTF8_STRING` and

--- a/src/tests/copy.rs
+++ b/src/tests/copy.rs
@@ -444,10 +444,7 @@ fn copy_multi_no_additional_text_mime_types_test() {
     assert!(mime_types.is_some());
     let mut mimes = mime_types.unwrap();
     mimes.sort();
-    assert_eq!(mimes,
-               ["TEXT",
-                "test",
-                "test2"]);
+    assert_eq!(mimes, ["TEXT", "test", "test2"]);
     assert_eq!(contents_test, [1, 3, 3, 7]);
     assert_eq!(contents_test2, [2, 4, 4]);
     assert_eq!(contents_text, b"hello TEXT");

--- a/src/tests/copy.rs
+++ b/src/tests/copy.rs
@@ -236,6 +236,7 @@ fn copy_multi_test() {
     let child = thread::spawn(move || {
         let mut opts = Options::new();
         opts.foreground(true);
+        opts.offer_additional_text_mimes(true);
         let sources = vec![MimeSource { source: Source::Bytes([1, 3, 3, 7][..].into()),
                                         mime_type: MimeType::Specific("test".to_string()) },
                            MimeSource { source: Source::Bytes([2, 4, 4][..].into()),

--- a/src/tests/copy.rs
+++ b/src/tests/copy.rs
@@ -236,7 +236,6 @@ fn copy_multi_test() {
     let child = thread::spawn(move || {
         let mut opts = Options::new();
         opts.foreground(true);
-        opts.offer_additional_text_mimes(true);
         let sources = vec![MimeSource { source: Source::Bytes([1, 3, 3, 7][..].into()),
                                         mime_type: MimeType::Specific("test".to_string()) },
                            MimeSource { source: Source::Bytes([2, 4, 4][..].into()),
@@ -319,6 +318,138 @@ fn copy_multi_test() {
     assert_eq!(contents_test, [1, 3, 3, 7]);
     assert_eq!(contents_test2, [2, 4, 4]);
     assert_eq!(contents_fallback, b"hello fallback");
+    assert_eq!(contents_text, b"hello TEXT");
+}
+
+#[test]
+fn copy_multi_no_additional_text_mime_types_test() {
+    struct ServerManagerHandler {
+        selection: Rc<RefCell<Option<ServerSource>>>,
+    }
+
+    impl ServerManagerHandler {
+        fn create_data_source(&mut self, id: Main<ServerSource>) {
+            id.as_ref().user_data().set(|| RefCell::new(Vec::<String>::new()));
+            id.quick_assign(|source, request, _| {
+                  if let ServerSourceRequest::Offer { mime_type } = request {
+                      source.as_ref()
+                            .user_data()
+                            .get::<RefCell<Vec<_>>>()
+                            .unwrap()
+                            .borrow_mut()
+                            .push(mime_type);
+                  }
+              });
+        }
+
+        fn get_data_device(&mut self, id: Main<ServerDevice>) {
+            let selection = self.selection.clone();
+            id.quick_assign(move |_, request, _| {
+                  if let ServerDeviceRequest::SetSelection { source } = request {
+                      *selection.borrow_mut() = source;
+                  }
+              });
+        }
+    }
+
+    let mut server = TestServer::new();
+    server.display
+          .create_global::<ServerSeat, _>(6, Filter::new(|_: (_, _), _, _| {}));
+
+    let selection = Rc::new(RefCell::new(None));
+    {
+        let selection = selection.clone();
+        server.display
+              .create_global::<ServerManager, _>(1,
+                                                 Filter::new(move |(manager, _): (Main<ServerManager>, _), _, _| {
+                                                     let mut handler =
+                                                         ServerManagerHandler { selection: selection.clone() };
+                                                     manager.quick_assign(move |_, request, _| match request {
+                                                                ServerManagerRequest::CreateDataSource { id } => {
+                                                                    handler.create_data_source(id)
+                                                                }
+                                                                ServerManagerRequest::GetDataDevice { id, .. } => {
+                                                                    handler.get_data_device(id)
+                                                                }
+                                                                _ => unreachable!(),
+                                                            });
+                                                 }));
+    }
+
+    let socket_name = mem::replace(&mut server.socket_name, OsString::new());
+    let child = thread::spawn(move || {
+        let mut opts = Options::new();
+        opts.foreground(true);
+        opts.omit_additional_text_mime_types(true);
+        let sources = vec![MimeSource { source: Source::Bytes([1, 3, 3, 7][..].into()),
+                                        mime_type: MimeType::Specific("test".to_string()) },
+                           MimeSource { source: Source::Bytes([2, 4, 4][..].into()),
+                                        mime_type: MimeType::Specific("test2".to_string()) },
+                           // Ignored because it's the second "test" MIME type.
+                           MimeSource { source: Source::Bytes([4, 3, 2, 1][..].into()),
+                                        mime_type: MimeType::Specific("test".to_string()) },
+                           // A specific override of an additional text type.
+                           MimeSource { source: Source::Bytes(b"hello TEXT"[..].into()),
+                                        mime_type: MimeType::Specific("TEXT".to_string()) },];
+        copy_internal(opts, sources, Some(socket_name))
+    });
+
+    thread::sleep(Duration::from_millis(100));
+    server.answer();
+
+    thread::sleep(Duration::from_millis(100));
+    server.answer();
+
+    thread::sleep(Duration::from_millis(100));
+    server.answer();
+
+    thread::sleep(Duration::from_millis(100));
+    server.answer();
+
+    let mime_types = selection.borrow().as_ref().map(|x| {
+                                                    x.as_ref()
+                                                     .user_data()
+                                                     .get::<RefCell<Vec<String>>>()
+                                                     .unwrap()
+                                                     .borrow()
+                                                     .clone()
+                                                });
+
+    let (mut read_test, write_test) = pipe().unwrap();
+    let (mut read_test2, write_test2) = pipe().unwrap();
+    let (mut read_text, write_text) = pipe().unwrap();
+
+    if let Some(source) = selection.borrow().as_ref() {
+        source.send("test".to_string(), write_test.as_raw_fd());
+        drop(write_test);
+        source.send("test2".to_string(), write_test2.as_raw_fd());
+        drop(write_test2);
+        source.send("TEXT".to_string(), write_text.as_raw_fd());
+        drop(write_text);
+        source.cancelled();
+    }
+
+    thread::sleep(Duration::from_millis(100));
+    server.answer();
+
+    let mut contents_test = vec![];
+    read_test.read_to_end(&mut contents_test).unwrap();
+    let mut contents_test2 = vec![];
+    read_test2.read_to_end(&mut contents_test2).unwrap();
+    let mut contents_text = vec![];
+    read_text.read_to_end(&mut contents_text).unwrap();
+
+    child.join().unwrap().unwrap();
+
+    assert!(mime_types.is_some());
+    let mut mimes = mime_types.unwrap();
+    mimes.sort();
+    assert_eq!(mimes,
+               ["TEXT",
+                "test",
+                "test2"]);
+    assert_eq!(contents_test, [1, 3, 3, 7]);
+    assert_eq!(contents_test2, [2, 4, 4]);
     assert_eq!(contents_text, b"hello TEXT");
 }
 


### PR DESCRIPTION
Fixes a little "bug" in my clipboard manager which made it offer plain text mimes when copying images (because of `text/html`) which in turn caused some weirdness in some programs.