### PR TITLE
Add support for ext-data-control

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,12 +38,12 @@ thiserror = "2"
 tree_magic_mini = "3.1.6"
 wayland-backend = "0.3.8"
 wayland-client = "0.31.8"
-wayland-protocols = { version = "0.32.6", features = ["client"] }
+wayland-protocols = { version = "0.32.6", features = ["client", "staging"] }
 wayland-protocols-wlr = { version = "0.3.6", features = ["client"] }
 
 [dev-dependencies]
 wayland-server = "0.31.7"
-wayland-protocols = { version = "0.32.6", features = ["server"] }
+wayland-protocols = { version = "0.32.6", features = ["server", "staging"] }
 wayland-protocols-wlr = { version = "0.3.6", features = ["server"] }
 proptest = "1.6.0"
 proptest-derive = "0.5.1"

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ please use the appropriate Wayland protocols for interacting with the Wayland cl
 primary selection), for example via the
 [smithay-clipboard](https://crates.io/crates/smithay-clipboard) crate.
 
-The protocol used for clipboard interaction is `data-control` from
-[wlroots](https://github.com/swaywm/wlr-protocols). When using the regular clipboard, the
-compositor must support the first version of the protocol. When using the "primary" clipboard,
-the compositor must support the second version of the protocol (or higher).
+The protocol used for clipboard interaction is `ext-data-control` or `wlr-data-control`. When
+using the regular clipboard, the compositor must support any version of either protocol. When
+using the "primary" clipboard, the compositor must support any version of `ext-data-control`,
+or the second version of the `wlr-data-control` protocol.
 
 For example applications using these features, see `wl-clipboard-rs-tools/src/bin/wl_copy.rs`
 and `wl-clipboard-rs-tools/src/bin/wl_paste.rs` which implement terminal apps similar to
@@ -72,19 +72,19 @@ use wl_clipboard_rs::utils::{is_primary_selection_supported, PrimarySelectionChe
 
 match is_primary_selection_supported() {
     Ok(supported) => {
-        // We have our definitive result. False means that either data-control version 1
-        // is present (which does not support the primary selection), or that data-control
-        // version 2 is present and it did not signal the primary selection support.
+        // We have our definitive result. False means that ext/wlr-data-control is present
+        // and did not signal the primary selection support, or that only wlr-data-control
+        // version 1 is present (which does not support primary selection).
     },
     Err(PrimarySelectionCheckError::NoSeats) => {
         // Impossible to give a definitive result. Primary selection may or may not be
         // supported.
 
-        // The required protocol (data-control version 2) is there, but there are no seats.
-        // Unfortunately, at least one seat is needed to check for the primary clipboard
-        // support.
+        // The required protocol (ext-data-control, or wlr-data-control version 2) is there,
+        // but there are no seats. Unfortunately, at least one seat is needed to check for the
+        // primary clipboard support.
     },
-    Err(PrimarySelectionCheckError::MissingProtocol { .. }) => {
+    Err(PrimarySelectionCheckError::MissingProtocol) => {
         // The data-control protocol (required for wl-clipboard-rs operation) is not
         // supported by the compositor.
     },

--- a/src/data_control.rs
+++ b/src/data_control.rs
@@ -1,0 +1,303 @@
+//! Abstraction over ext/wlr-data-control.
+
+use std::os::fd::BorrowedFd;
+
+use ext::ext_data_control_device_v1::ExtDataControlDeviceV1;
+use ext::ext_data_control_manager_v1::ExtDataControlManagerV1;
+use ext::ext_data_control_offer_v1::ExtDataControlOfferV1;
+use ext::ext_data_control_source_v1::ExtDataControlSourceV1;
+use wayland_client::protocol::wl_seat::WlSeat;
+use wayland_client::{Dispatch, Proxy as _, QueueHandle};
+use wayland_protocols::ext::data_control::v1::client as ext;
+use wayland_protocols_wlr::data_control::v1::client as zwlr;
+use zwlr::zwlr_data_control_device_v1::ZwlrDataControlDeviceV1;
+use zwlr::zwlr_data_control_manager_v1::ZwlrDataControlManagerV1;
+use zwlr::zwlr_data_control_offer_v1::ZwlrDataControlOfferV1;
+use zwlr::zwlr_data_control_source_v1::ZwlrDataControlSourceV1;
+
+#[derive(Clone)]
+pub enum Manager {
+    Zwlr(ZwlrDataControlManagerV1),
+    Ext(ExtDataControlManagerV1),
+}
+
+#[derive(Clone)]
+pub enum Device {
+    Zwlr(ZwlrDataControlDeviceV1),
+    Ext(ExtDataControlDeviceV1),
+}
+
+#[derive(Clone)]
+pub enum Source {
+    Zwlr(ZwlrDataControlSourceV1),
+    Ext(ExtDataControlSourceV1),
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum Offer {
+    Zwlr(ZwlrDataControlOfferV1),
+    Ext(ExtDataControlOfferV1),
+}
+
+impl Manager {
+    pub fn get_data_device<D, U>(&self, seat: &WlSeat, qh: &QueueHandle<D>, udata: U) -> Device
+    where
+        D: Dispatch<ZwlrDataControlDeviceV1, U> + 'static,
+        D: Dispatch<ExtDataControlDeviceV1, U> + 'static,
+        U: Send + Sync + 'static,
+    {
+        match self {
+            Manager::Zwlr(manager) => Device::Zwlr(manager.get_data_device(seat, qh, udata)),
+            Manager::Ext(manager) => Device::Ext(manager.get_data_device(seat, qh, udata)),
+        }
+    }
+
+    pub fn create_data_source<D>(&self, qh: &QueueHandle<D>) -> Source
+    where
+        D: Dispatch<ZwlrDataControlSourceV1, ()> + 'static,
+        D: Dispatch<ExtDataControlSourceV1, ()> + 'static,
+    {
+        match self {
+            Manager::Zwlr(manager) => Source::Zwlr(manager.create_data_source(qh, ())),
+            Manager::Ext(manager) => Source::Ext(manager.create_data_source(qh, ())),
+        }
+    }
+}
+
+impl Device {
+    pub fn destroy(&self) {
+        match self {
+            Device::Zwlr(device) => device.destroy(),
+            Device::Ext(device) => device.destroy(),
+        }
+    }
+
+    #[track_caller]
+    pub fn set_selection(&self, source: Option<&Source>) {
+        match self {
+            Device::Zwlr(device) => device.set_selection(source.map(Source::zwlr)),
+            Device::Ext(device) => device.set_selection(source.map(Source::ext)),
+        }
+    }
+
+    #[track_caller]
+    pub fn set_primary_selection(&self, source: Option<&Source>) {
+        match self {
+            Device::Zwlr(device) => device.set_primary_selection(source.map(Source::zwlr)),
+            Device::Ext(device) => device.set_primary_selection(source.map(Source::ext)),
+        }
+    }
+}
+
+impl Source {
+    pub fn destroy(&self) {
+        match self {
+            Source::Zwlr(source) => source.destroy(),
+            Source::Ext(source) => source.destroy(),
+        }
+    }
+
+    pub fn offer(&self, mime_type: String) {
+        match self {
+            Source::Zwlr(source) => source.offer(mime_type),
+            Source::Ext(source) => source.offer(mime_type),
+        }
+    }
+
+    pub fn is_alive(&self) -> bool {
+        match self {
+            Source::Zwlr(source) => source.is_alive(),
+            Source::Ext(source) => source.is_alive(),
+        }
+    }
+
+    #[track_caller]
+    pub fn zwlr(&self) -> &ZwlrDataControlSourceV1 {
+        if let Self::Zwlr(v) = self {
+            v
+        } else {
+            panic!("tried to convert non-Zwlr Source to Zwlr")
+        }
+    }
+
+    #[track_caller]
+    pub fn ext(&self) -> &ExtDataControlSourceV1 {
+        if let Self::Ext(v) = self {
+            v
+        } else {
+            panic!("tried to convert non-Ext Source to Ext")
+        }
+    }
+}
+
+impl Offer {
+    pub fn destroy(&self) {
+        match self {
+            Offer::Zwlr(offer) => offer.destroy(),
+            Offer::Ext(offer) => offer.destroy(),
+        }
+    }
+
+    pub fn receive(&self, mime_type: String, fd: BorrowedFd) {
+        match self {
+            Offer::Zwlr(offer) => offer.receive(mime_type, fd),
+            Offer::Ext(offer) => offer.receive(mime_type, fd),
+        }
+    }
+}
+
+impl From<ZwlrDataControlSourceV1> for Source {
+    fn from(v: ZwlrDataControlSourceV1) -> Self {
+        Self::Zwlr(v)
+    }
+}
+
+impl From<ExtDataControlSourceV1> for Source {
+    fn from(v: ExtDataControlSourceV1) -> Self {
+        Self::Ext(v)
+    }
+}
+
+impl From<ZwlrDataControlOfferV1> for Offer {
+    fn from(v: ZwlrDataControlOfferV1) -> Self {
+        Self::Zwlr(v)
+    }
+}
+
+impl From<ExtDataControlOfferV1> for Offer {
+    fn from(v: ExtDataControlOfferV1) -> Self {
+        Self::Ext(v)
+    }
+}
+
+// Some mildly cursed macros to avoid code duplication.
+macro_rules! impl_dispatch_manager {
+    ($handler:ty => [$($iface:ty),*]) => {
+        $(
+            impl Dispatch<$iface, ()> for $handler {
+                fn event(
+                    _state: &mut Self,
+                    _proxy: &$iface,
+                    _event: <$iface as wayland_client::Proxy>::Event,
+                    _data: &(),
+                    _conn: &wayland_client::Connection,
+                    _qhandle: &wayland_client::QueueHandle<Self>,
+                ) {
+                }
+            }
+        )*
+    };
+
+    ($handler:ty) => {
+        impl_dispatch_manager!($handler => [
+            wayland_protocols_wlr::data_control::v1::client::zwlr_data_control_manager_v1::ZwlrDataControlManagerV1,
+            wayland_protocols::ext::data_control::v1::client::ext_data_control_manager_v1::ExtDataControlManagerV1
+        ]);
+    };
+}
+pub(crate) use impl_dispatch_manager;
+
+macro_rules! impl_dispatch_device {
+    ($handler:ty, $udata:ty, $code:expr => [$(($iface:ty, $opcode:path, $offer:ty)),*]) => {
+        $(
+            impl Dispatch<$iface, $udata> for $handler {
+                fn event(
+                    state: &mut Self,
+                    _proxy: &$iface,
+                    event: <$iface as wayland_client::Proxy>::Event,
+                    data: &$udata,
+                    _conn: &wayland_client::Connection,
+                    _qhandle: &wayland_client::QueueHandle<Self>,
+                ) {
+                    type Event = <$iface as wayland_client::Proxy>::Event;
+
+                    ($code)(state, event, data)
+                }
+
+                event_created_child!($handler, $iface, [
+                    $opcode => ($offer, ()),
+                ]);
+            }
+        )*
+    };
+
+    ($handler:ty, $udata:ty, $code:expr) => {
+        impl_dispatch_device!($handler, $udata, $code => [
+            (
+                wayland_protocols_wlr::data_control::v1::client::zwlr_data_control_device_v1::ZwlrDataControlDeviceV1,
+                wayland_protocols_wlr::data_control::v1::client::zwlr_data_control_device_v1::EVT_DATA_OFFER_OPCODE,
+                wayland_protocols_wlr::data_control::v1::client::zwlr_data_control_offer_v1::ZwlrDataControlOfferV1
+            ),
+            (
+                wayland_protocols::ext::data_control::v1::client::ext_data_control_device_v1::ExtDataControlDeviceV1,
+                wayland_protocols::ext::data_control::v1::client::ext_data_control_device_v1::EVT_DATA_OFFER_OPCODE,
+                wayland_protocols::ext::data_control::v1::client::ext_data_control_offer_v1::ExtDataControlOfferV1
+            )
+        ]);
+    };
+}
+pub(crate) use impl_dispatch_device;
+
+macro_rules! impl_dispatch_source {
+    ($handler:ty, $code:expr => [$($iface:ty),*]) => {
+        $(
+            impl Dispatch<$iface, ()> for $handler {
+                fn event(
+                    state: &mut Self,
+                    proxy: &$iface,
+                    event: <$iface as wayland_client::Proxy>::Event,
+                    _data: &(),
+                    _conn: &wayland_client::Connection,
+                    _qhandle: &wayland_client::QueueHandle<Self>,
+                ) {
+                    type Event = <$iface as wayland_client::Proxy>::Event;
+
+                    let source = $crate::data_control::Source::from(proxy.clone());
+                    ($code)(state, source, event)
+                }
+            }
+        )*
+    };
+
+    ($handler:ty, $code:expr) => {
+        impl_dispatch_source!($handler, $code => [
+            wayland_protocols_wlr::data_control::v1::client::zwlr_data_control_source_v1::ZwlrDataControlSourceV1,
+            wayland_protocols::ext::data_control::v1::client::ext_data_control_source_v1::ExtDataControlSourceV1
+        ]);
+    };
+}
+pub(crate) use impl_dispatch_source;
+
+macro_rules! impl_dispatch_offer {
+    ($handler:ty, $code:expr => [$($iface:ty),*]) => {
+        $(
+            impl Dispatch<$iface, ()> for $handler {
+                fn event(
+                    state: &mut Self,
+                    proxy: &$iface,
+                    event: <$iface as wayland_client::Proxy>::Event,
+                    _data: &(),
+                    _conn: &wayland_client::Connection,
+                    _qhandle: &wayland_client::QueueHandle<Self>,
+                ) {
+                    type Event = <$iface as wayland_client::Proxy>::Event;
+
+                    let offer = $crate::data_control::Offer::from(proxy.clone());
+                    ($code)(state, offer, event)
+                }
+            }
+        )*
+    };
+
+    ($handler:ty, $code:expr) => {
+        impl_dispatch_offer!($handler, $code => [
+            wayland_protocols_wlr::data_control::v1::client::zwlr_data_control_offer_v1::ZwlrDataControlOfferV1,
+            wayland_protocols::ext::data_control::v1::client::ext_data_control_offer_v1::ExtDataControlOfferV1
+        ]);
+    };
+
+    ($handler:ty) => {
+        impl_dispatch_offer!($handler, |_, _, _: Event| ());
+    };
+}
+pub(crate) use impl_dispatch_offer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,10 @@
 //! primary selection), for example via the
 //! [smithay-clipboard](https://crates.io/crates/smithay-clipboard) crate.
 //!
-//! The protocol used for clipboard interaction is `data-control` from
-//! [wlroots](https://github.com/swaywm/wlr-protocols). When using the regular clipboard, the
-//! compositor must support the first version of the protocol. When using the "primary" clipboard,
-//! the compositor must support the second version of the protocol (or higher).
+//! The protocol used for clipboard interaction is `ext-data-control` or `wlr-data-control`. When
+//! using the regular clipboard, the compositor must support any version of either protocol. When
+//! using the "primary" clipboard, the compositor must support any version of `ext-data-control`,
+//! or the second version of the `wlr-data-control` protocol.
 //!
 //! For example applications using these features, see `wl-clipboard-rs-tools/src/bin/wl_copy.rs`
 //! and `wl-clipboard-rs-tools/src/bin/wl_paste.rs` which implement terminal apps similar to
@@ -74,19 +74,19 @@
 //!
 //! match is_primary_selection_supported() {
 //!     Ok(supported) => {
-//!         // We have our definitive result. False means that either data-control version 1
-//!         // is present (which does not support the primary selection), or that data-control
-//!         // version 2 is present and it did not signal the primary selection support.
+//!         // We have our definitive result. False means that ext/wlr-data-control is present
+//!         // and did not signal the primary selection support, or that only wlr-data-control
+//!         // version 1 is present (which does not support primary selection).
 //!     },
 //!     Err(PrimarySelectionCheckError::NoSeats) => {
 //!         // Impossible to give a definitive result. Primary selection may or may not be
 //!         // supported.
 //!
-//!         // The required protocol (data-control version 2) is there, but there are no seats.
-//!         // Unfortunately, at least one seat is needed to check for the primary clipboard
-//!         // support.
+//!         // The required protocol (ext-data-control, or wlr-data-control version 2) is there,
+//!         // but there are no seats. Unfortunately, at least one seat is needed to check for the
+//!         // primary clipboard support.
 //!     },
-//!     Err(PrimarySelectionCheckError::MissingProtocol { .. }) => {
+//!     Err(PrimarySelectionCheckError::MissingProtocol) => {
 //!         // The data-control protocol (required for wl-clipboard-rs operation) is not
 //!         // supported by the compositor.
 //!     },
@@ -109,6 +109,7 @@
 #![deny(unsafe_code)]
 
 mod common;
+mod data_control;
 mod seat_data;
 
 #[cfg(test)]

--- a/src/seat_data.rs
+++ b/src/seat_data.rs
@@ -1,5 +1,4 @@
-use wayland_protocols_wlr::data_control::v1::client::zwlr_data_control_device_v1::ZwlrDataControlDeviceV1;
-use wayland_protocols_wlr::data_control::v1::client::zwlr_data_control_offer_v1::ZwlrDataControlOfferV1;
+use crate::data_control::{Device, Offer};
 
 #[derive(Default)]
 pub struct SeatData {
@@ -7,13 +6,13 @@ pub struct SeatData {
     pub name: Option<String>,
 
     /// The data device of this seat, if any.
-    pub device: Option<ZwlrDataControlDeviceV1>,
+    pub device: Option<Device>,
 
     /// The data offer of this seat, if any.
-    pub offer: Option<ZwlrDataControlOfferV1>,
+    pub offer: Option<Offer>,
 
     /// The primary-selection data offer of this seat, if any.
-    pub primary_offer: Option<ZwlrDataControlOfferV1>,
+    pub primary_offer: Option<Offer>,
 }
 
 impl SeatData {
@@ -25,7 +24,7 @@ impl SeatData {
     /// Sets this seat's device.
     ///
     /// Destroys the old one, if any.
-    pub fn set_device(&mut self, device: Option<ZwlrDataControlDeviceV1>) {
+    pub fn set_device(&mut self, device: Option<Device>) {
         let old_device = self.device.take();
         self.device = device;
 
@@ -37,7 +36,7 @@ impl SeatData {
     /// Sets this seat's data offer.
     ///
     /// Destroys the old one, if any.
-    pub fn set_offer(&mut self, new_offer: Option<ZwlrDataControlOfferV1>) {
+    pub fn set_offer(&mut self, new_offer: Option<Offer>) {
         let old_offer = self.offer.take();
         self.offer = new_offer;
 
@@ -49,7 +48,7 @@ impl SeatData {
     /// Sets this seat's primary-selection data offer.
     ///
     /// Destroys the old one, if any.
-    pub fn set_primary_offer(&mut self, new_offer: Option<ZwlrDataControlOfferV1>) {
+    pub fn set_primary_offer(&mut self, new_offer: Option<Offer>) {
         let old_offer = self.primary_offer.take();
         self.primary_offer = new_offer;
 

--- a/src/tests/paste.rs
+++ b/src/tests/paste.rs
@@ -65,13 +65,7 @@ fn get_mime_types_no_data_control() {
 
     let result =
         get_mime_types_internal(ClipboardType::Regular, Seat::Unspecified, Some(socket_name));
-    assert!(matches!(
-        result,
-        Err(Error::MissingProtocol {
-            name: "zwlr_data_control_manager_v1",
-            version: 1
-        })
-    ));
+    assert!(matches!(result, Err(Error::MissingProtocol { version: 1 })));
 }
 
 #[test]
@@ -94,13 +88,7 @@ fn get_mime_types_no_data_control_2() {
 
     let result =
         get_mime_types_internal(ClipboardType::Primary, Seat::Unspecified, Some(socket_name));
-    assert!(matches!(
-        result,
-        Err(Error::MissingProtocol {
-            name: "zwlr_data_control_manager_v1",
-            version: 2
-        })
-    ));
+    assert!(matches!(result, Err(Error::MissingProtocol { version: 2 })));
 }
 
 #[test]


### PR DESCRIPTION
Since the protocol is more or less exactly the same as wlr-data-control, I added some wrappers and macros to re-use the same existing code for both protocols.

Some things I didn't do because it seemed like too much effort:
1. Would be nice to add new traits over the types in `data_control` instead of macros to reduce the curse and to avoid duplicate codegen.
2. I didn't add copy and paste tests over ext-data-control; don't think it's worth the effort since it would be using the same server-side impl code anyway.

The only (if I didn't miss something) API breaking change is that I got rid of `name` in the `MissingProtocol` error and instead spelled it out in the message. This is not strictly required, but might as well do it, I'll bump minor for this anyway.

@bugaevc wanna take a look? I tested this on niri v25.02, verifying via WAYLAND_DEBUG that it used ext-data-control.

The diff is best viewed ignoring whitespace.