### PR TITLE
Correct the comment about fork behavior 

### DIFF
--- a/wl-clipboard-rs-tools/src/bin/wl-copy.rs
+++ b/wl-clipboard-rs-tools/src/bin/wl-copy.rs
@@ -85,8 +85,6 @@ fn main() -> Result<(), anyhow::Error> {
     if foreground {
         prepared_copy.serve()?;
     } else {
-        // SAFETY: We don't spawn any threads, so doing things after forking is safe.
-        // TODO: is there any way to verify that we don't spawn any threads?
         match unsafe { fork() } {
             -1 => panic!("error forking: {:?}", std::io::Error::last_os_error()),
             0 => {


### PR DESCRIPTION
[fork(2)](https://man7.org/linux/man-pages/man2/fork.2.html).

```rust
match unsafe { fork() } {
    0 => println!("child process {}", std::process::id()),
    pid => println!("parent process {}, child process pid {}", std::process::id(), pid),
}
```

```console
$ cargo run
parent process 21083, child process pid 21282
child process 21282
```