### PR TITLE
preserve order of MIME types

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -22,6 +22,7 @@ pub struct State {
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[allow(clippy::enum_variant_names)]
     #[error("Couldn't open the provided Wayland socket")]
     SocketOpenError(#[source] io::Error),
 

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -250,6 +250,8 @@ fn get_offer(
 
 /// Retrieves the offered MIME types.
 ///
+/// Also see [`get_mime_types_ordered()`], an order-preserving version.
+///
 /// If `seat` is `None`, uses an unspecified seat (it depends on the order returned by the
 /// compositor). This is perfectly fine when only a single seat is present, so for most
 /// configurations.
@@ -276,7 +278,18 @@ pub fn get_mime_types(clipboard: ClipboardType, seat: Seat<'_>) -> Result<HashSe
         .collect())
 }
 
-/// Retrieves the offered MIME types. Preserves the original order.
+/// Retrieves the offered MIME types, preserving their original order.
+///
+/// Applications are generally expected to offer not just the "native" data type, but some
+/// conversions generated on the fly. For example, when copying a PNG image from a browser, it will
+/// offer `image/png` as well as `image/jpeg`, `image/webp`, and others, to maximize compatibility.
+/// When these converted MIME types are pasted, the application will generate the data on the fly
+/// (by converting the image to the requested MIME type).
+///
+/// There's no defined way to know which of the offered MIME types is native (if any). However,
+/// some applications will offer the native data types first, followed by converted ones. While
+/// [`get_mime_types()`] loses this order (a `HashSet` is unordered), this function returns the
+/// MIME types in their original order.
 ///
 /// If `seat` is `None`, uses an unspecified seat (it depends on the order returned by the
 /// compositor). This is perfectly fine when only a single seat is present, so for most
@@ -371,14 +384,15 @@ pub(crate) fn get_contents_internal(
     let primary = clipboard == ClipboardType::Primary;
     let (mut queue, mut state, offer) = get_offer(primary, seat, socket_name)?;
 
-    let mime_types_ordered = state.offers.remove(&offer).unwrap();
+    let mut mime_types = state.offers.remove(&offer).unwrap();
 
     macro_rules! take {
         ($pred:expr) => {
             'block: {
-                for s in mime_types_ordered.iter() {
-                    if $pred(s) {
-                        break 'block Some(s.as_str());
+                for i in 0..mime_types.len() {
+                    if $pred(&mime_types[i]) {
+                        // We only remove once, so the swap doesn't affect anything.
+                        break 'block Some(mime_types.swap_remove(i));
                     }
                 }
                 None
@@ -407,7 +421,7 @@ pub(crate) fn get_contents_internal(
         return Err(Error::NoMimeType);
     }
 
-    let mime_type = mime_type.unwrap().to_string();
+    let mime_type = mime_type.unwrap();
 
     // Create a pipe for content transfer.
     let (read, write) = pipe().map_err(Error::PipeCreation)?;

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -70,7 +70,7 @@ struct State {
     common: common::State,
     // The value is the set of MIME types in the offer.
     // TODO: We never remove offers from here, even if we don't use them or after destroying them.
-    offers: HashMap<data_control::Offer, HashSet<String>>,
+    offers: HashMap<data_control::Offer, Vec<String>>,
     got_primary_selection: bool,
 }
 
@@ -155,7 +155,7 @@ impl_dispatch_device!(State, WlSeat, |state: &mut Self, event, seat| {
     match event {
         Event::DataOffer { id } => {
             let offer = data_control::Offer::from(id);
-            state.offers.insert(offer, HashSet::new());
+            state.offers.insert(offer, Vec::new());
         }
         Event::Selection { id } => {
             let offer = id.map(data_control::Offer::from);
@@ -181,7 +181,7 @@ impl_dispatch_offer!(State, |state: &mut Self,
                              offer: data_control::Offer,
                              event| {
     if let Event::Offer { mime_type } = event {
-        state.offers.get_mut(&offer).unwrap().insert(mime_type);
+        state.offers.get_mut(&offer).unwrap().push(mime_type);
     }
 });
 
@@ -271,6 +271,37 @@ fn get_offer(
 /// ```
 #[inline]
 pub fn get_mime_types(clipboard: ClipboardType, seat: Seat<'_>) -> Result<HashSet<String>, Error> {
+    Ok(get_mime_types_internal(clipboard, seat, None)?
+        .into_iter()
+        .collect())
+}
+
+/// Retrieves the offered MIME types. Preserves the original order.
+///
+/// If `seat` is `None`, uses an unspecified seat (it depends on the order returned by the
+/// compositor). This is perfectly fine when only a single seat is present, so for most
+/// configurations.
+///
+/// # Examples
+///
+/// ```no_run
+/// # extern crate wl_clipboard_rs;
+/// # use wl_clipboard_rs::paste::Error;
+/// # fn foo() -> Result<(), Error> {
+/// use wl_clipboard_rs::{paste::{get_mime_types_ordered, ClipboardType, Seat}};
+///
+/// let mime_types = get_mime_types_ordered(ClipboardType::Regular, Seat::Unspecified)?;
+/// for mime_type in mime_types {
+///     println!("{}", mime_type);
+/// }
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn get_mime_types_ordered(
+    clipboard: ClipboardType,
+    seat: Seat<'_>,
+) -> Result<Vec<String>, Error> {
     get_mime_types_internal(clipboard, seat, None)
 }
 
@@ -279,7 +310,7 @@ pub(crate) fn get_mime_types_internal(
     clipboard: ClipboardType,
     seat: Seat<'_>,
     socket_name: Option<OsString>,
-) -> Result<HashSet<String>, Error> {
+) -> Result<Vec<String>, Error> {
     let primary = clipboard == ClipboardType::Primary;
     let (_, mut state, offer) = get_offer(primary, seat, socket_name)?;
     Ok(state.offers.remove(&offer).unwrap())
@@ -340,25 +371,35 @@ pub(crate) fn get_contents_internal(
     let primary = clipboard == ClipboardType::Primary;
     let (mut queue, mut state, offer) = get_offer(primary, seat, socket_name)?;
 
-    let mut mime_types = state.offers.remove(&offer).unwrap();
+    let mime_types_ordered = state.offers.remove(&offer).unwrap();
+
+    macro_rules! take {
+        ($pred:expr) => {
+            'block: {
+                for s in mime_types_ordered.iter() {
+                    if $pred(s) {
+                        break 'block Some(s.as_str());
+                    }
+                }
+                None
+            }
+        };
+    }
 
     // Find the desired MIME type.
     let mime_type = match mime_type {
-        MimeType::Any => mime_types
-            .take("text/plain;charset=utf-8")
-            .or_else(|| mime_types.take("UTF8_STRING"))
-            .or_else(|| mime_types.iter().find(|x| is_text(x)).cloned())
-            .or_else(|| mime_types.drain().next()),
-        MimeType::Text => mime_types
-            .take("text/plain;charset=utf-8")
-            .or_else(|| mime_types.take("UTF8_STRING"))
-            .or_else(|| mime_types.drain().find(|x| is_text(x))),
-        MimeType::TextWithPriority(priority) => mime_types
-            .take(priority)
-            .or_else(|| mime_types.take("text/plain;charset=utf-8"))
-            .or_else(|| mime_types.take("UTF8_STRING"))
-            .or_else(|| mime_types.drain().find(|x| is_text(x))),
-        MimeType::Specific(mime_type) => mime_types.take(mime_type),
+        MimeType::Any => take!(|x| x == "text/plain;charset=utf-8")
+            .or_else(|| take!(|x| x == "UTF8_STRING"))
+            .or_else(|| take!(is_text))
+            .or_else(|| take!(|_| true)),
+        MimeType::Text => take!(|x| x == "text/plain;charset=utf-8")
+            .or_else(|| take!(|x| x == "UTF8_STRING"))
+            .or_else(|| take!(is_text)),
+        MimeType::TextWithPriority(priority) => take!(|x| x == priority)
+            .or_else(|| take!(|x| x == "text/plain;charset=utf-8"))
+            .or_else(|| take!(|x| x == "UTF8_STRING"))
+            .or_else(|| take!(is_text)),
+        MimeType::Specific(mime_type) => take!(|x| x == mime_type),
     };
 
     // Check if a suitable MIME type is copied.
@@ -366,7 +407,7 @@ pub(crate) fn get_contents_internal(
         return Err(Error::NoMimeType);
     }
 
-    let mime_type = mime_type.unwrap();
+    let mime_type = mime_type.unwrap().to_string();
 
     // Create a pipe for content transfer.
     let (read, write) = pipe().map_err(Error::PipeCreation)?;

--- a/src/tests/copy.rs
+++ b/src/tests/copy.rs
@@ -393,7 +393,7 @@ proptest! {
         match &mime_type {
             MimeType::Autodetect => unreachable!(),
             MimeType::Text => assert_eq!(mime_types, ["text/plain"]),
-            MimeType::Specific(mime) => assert_eq!(mime_types, [mime.clone()]),
+            MimeType::Specific(mime) => assert_eq!(mime_types, std::slice::from_ref(mime)),
         }
 
         let paste_mime_type = match mime_type {

--- a/src/tests/copy.rs
+++ b/src/tests/copy.rs
@@ -25,10 +25,10 @@ fn clear_test() {
             "seat0".into(),
             SeatInfo {
                 offer: Some(OfferInfo::Buffered {
-                    data: HashMap::from([("regular".into(), vec![1, 2, 3])]),
+                    data: vec![("regular".into(), vec![1, 2, 3])],
                 }),
                 primary_offer: Some(OfferInfo::Buffered {
-                    data: HashMap::from([("primary".into(), vec![1, 2, 3])]),
+                    data: vec![("primary".into(), vec![1, 2, 3])],
                 }),
             },
         )]),

--- a/src/tests/paste.rs
+++ b/src/tests/paste.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::io::Read;
 
 use proptest::prelude::*;
@@ -21,11 +21,11 @@ fn get_mime_types_test() {
             "seat0".into(),
             SeatInfo {
                 offer: Some(OfferInfo::Buffered {
-                    data: HashMap::from([
+                    data: vec![
                         ("first".into(), vec![]),
                         ("second".into(), vec![]),
                         ("third".into(), vec![]),
-                    ]),
+                    ],
                 }),
                 ..Default::default()
             },
@@ -41,7 +41,7 @@ fn get_mime_types_test() {
         get_mime_types_internal(ClipboardType::Regular, Seat::Unspecified, Some(socket_name))
             .unwrap();
 
-    let expected = HashSet::from(["first", "second", "third"].map(String::from));
+    let expected = Vec::from(["first", "second", "third"].map(String::from));
     assert_eq!(mime_types, expected);
 }
 
@@ -171,11 +171,11 @@ fn get_mime_types_specific_seat() {
                 "yay".into(),
                 SeatInfo {
                     offer: Some(OfferInfo::Buffered {
-                        data: HashMap::from([
+                        data: vec![
                             ("first".into(), vec![]),
                             ("second".into(), vec![]),
                             ("third".into(), vec![]),
-                        ]),
+                        ],
                     }),
                     ..Default::default()
                 },
@@ -195,7 +195,7 @@ fn get_mime_types_specific_seat() {
     )
     .unwrap();
 
-    let expected = HashSet::from(["first", "second", "third"].map(String::from));
+    let expected = Vec::from(["first", "second", "third"].map(String::from));
     assert_eq!(mime_types, expected);
 }
 
@@ -212,11 +212,11 @@ fn get_mime_types_primary() {
             "seat0".into(),
             SeatInfo {
                 primary_offer: Some(OfferInfo::Buffered {
-                    data: HashMap::from([
+                    data: vec![
                         ("first".into(), vec![]),
                         ("second".into(), vec![]),
                         ("third".into(), vec![]),
-                    ]),
+                    ],
                 }),
                 ..Default::default()
             },
@@ -232,7 +232,7 @@ fn get_mime_types_primary() {
         get_mime_types_internal(ClipboardType::Primary, Seat::Unspecified, Some(socket_name))
             .unwrap();
 
-    let expected = HashSet::from(["first", "second", "third"].map(String::from));
+    let expected = Vec::from(["first", "second", "third"].map(String::from));
     assert_eq!(mime_types, expected);
 }
 
@@ -249,7 +249,7 @@ fn get_contents_test() {
             "seat0".into(),
             SeatInfo {
                 offer: Some(OfferInfo::Buffered {
-                    data: HashMap::from([("application/octet-stream".into(), vec![1, 3, 3, 7])]),
+                    data: vec![("application/octet-stream".into(), vec![1, 3, 3, 7])],
                 }),
                 ..Default::default()
             },
@@ -289,7 +289,7 @@ fn get_contents_wrong_mime_type() {
             "seat0".into(),
             SeatInfo {
                 offer: Some(OfferInfo::Buffered {
-                    data: HashMap::from([("application/octet-stream".into(), vec![1, 3, 3, 7])]),
+                    data: vec![("application/octet-stream".into(), vec![1, 3, 3, 7])],
                 }),
                 ..Default::default()
             },
@@ -351,7 +351,7 @@ proptest! {
             };
             match expected_offer {
                 None => prop_assert!(matches!(result, Err(Error::ClipboardEmpty))),
-                Some(offer) => prop_assert_eq!(result.unwrap(), offer.data().keys().cloned().collect()),
+                Some(offer) => prop_assert_eq!(result.unwrap(), offer.data().iter().map(|(k, _)| k.clone()).collect::<Vec<String>>()),
             }
         }
     }
@@ -391,7 +391,7 @@ proptest! {
             let mime_type = match expected_offer {
                 Some(offer) if !offer.data().is_empty() => {
                     let mime_index = mime_index.index(offer.data().len());
-                    Some(offer.data().keys().nth(mime_index).unwrap())
+                    Some(offer.data().iter().map(|(k, _)| k).nth(mime_index).unwrap())
                 }
                 _ => None,
             };
@@ -418,7 +418,7 @@ proptest! {
 
                         let mut contents = vec![];
                         read.read_to_end(&mut contents).unwrap();
-                        prop_assert_eq!(&contents, &offer.data()[mime_type]);
+                        prop_assert_eq!(&contents, offer.data().iter().find(|(k, _)| k == mime_type).map(|(_, v)| &v[..]).unwrap());
                     }
                 },
             }

--- a/src/tests/state.rs
+++ b/src/tests/state.rs
@@ -38,9 +38,9 @@ use crate::server_ignore_global_impl;
 pub enum OfferInfo {
     Buffered {
         #[proptest(
-            strategy = "prop::collection::hash_map(any::<String>(), prop::collection::vec(any::<u8>(), 0..5), 0..5)"
+            strategy = "prop::collection::vec((any::<String>(), prop::collection::vec(any::<u8>(), 0..5)), 0..5)"
         )]
-        data: HashMap<String, Vec<u8>>,
+        data: Vec<(String, Vec<u8>)>,
     },
     #[proptest(skip)]
     Runtime { source: ZwlrDataControlSourceV1 },
@@ -48,21 +48,19 @@ pub enum OfferInfo {
 
 impl Default for OfferInfo {
     fn default() -> Self {
-        Self::Buffered {
-            data: HashMap::new(),
-        }
+        Self::Buffered { data: Vec::new() }
     }
 }
 
 impl OfferInfo {
     fn mime_types(&self, state: &State) -> Vec<String> {
         match self {
-            OfferInfo::Buffered { data } => data.keys().cloned().collect(),
+            OfferInfo::Buffered { data } => data.iter().map(|(k, _)| k).cloned().collect(),
             OfferInfo::Runtime { source } => state.sources[source].clone(),
         }
     }
 
-    pub fn data(&self) -> &HashMap<String, Vec<u8>> {
+    pub fn data(&self) -> &Vec<(String, Vec<u8>)> {
         match self {
             OfferInfo::Buffered { data } => data,
             OfferInfo::Runtime { .. } => panic!(),
@@ -257,7 +255,12 @@ impl Dispatch<ZwlrDataControlOfferV1, (String, bool)> for State {
             match offer_info {
                 OfferInfo::Buffered { data } => {
                     let mut write = PipeWriter::from(fd);
-                    let _ = write.write_all(&data[mime_type.as_str()]);
+                    let _ = write.write_all(
+                        data.iter()
+                            .find(|(k, _)| k == &mime_type)
+                            .map(|(_, v)| &v[..])
+                            .unwrap(),
+                    );
                 }
                 OfferInfo::Runtime { source } => {
                     if state.set_nonblock_on_write_fd {

--- a/wl-clipboard-rs-tools/src/bin/wl-paste.rs
+++ b/wl-clipboard-rs-tools/src/bin/wl-paste.rs
@@ -41,7 +41,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     // If listing types is requested, do just that.
     if options.list_types {
-        let mime_types = get_mime_types(primary, seat)?;
+        let mime_types = get_mime_types_ordered(primary, seat)?;
 
         for mime_type in mime_types.iter() {
             println!("{}", mime_type);


### PR DESCRIPTION
`MimeType::Any` says "the requested MIME type is unspecified and depends on the order they are received from the Wayland compositor", however, they were put into a `HashSet`, so the order was lost. Similarly, `get_mime_types` scrambled the order so that `wl-paste -l` lost potential information, like the native image of a screenshot being listed first.