### PR TITLE
copy: simplify source text handling

### DIFF
--- a/wl-clipboard-rs-tools/src/bin/wl-copy.rs
+++ b/wl-clipboard-rs-tools/src/bin/wl-copy.rs
@@ -1,5 +1,5 @@
+use std::fs::OpenOptions;
 use std::os::unix::ffi::OsStringExt;
-use std::{ffi::OsStr, fs::OpenOptions};
 
 use clap::Parser;
 use libc::fork;
@@ -51,10 +51,14 @@ fn main() -> Result<(), anyhow::Error> {
         return Ok(());
     }
 
-    let source = if options.text.is_empty() {
-        Source::StdIn
-    } else {
-        Source::Bytes(options.text.join(OsStr::new(" ")).into_vec().into())
+    // Join arguments into a string to copy, or use stdin if no arguments.
+    let source = match options.text.drain(..).reduce(|mut text, arg| {
+        text.push(" ");
+        text.push(arg);
+        text
+    }) {
+        None => Source::StdIn,
+        Some(text) => Source::Bytes(text.into_vec().into()),
     };
 
     let mime_type = if let Some(mime_type) = options.mime_type.take() {

--- a/wl-clipboard-rs-tools/src/bin/wl-copy.rs
+++ b/wl-clipboard-rs-tools/src/bin/wl-copy.rs
@@ -1,5 +1,5 @@
-use std::fs::OpenOptions;
 use std::os::unix::ffi::OsStringExt;
+use std::{ffi::OsStr, fs::OpenOptions};
 
 use clap::Parser;
 use libc::fork;
@@ -51,26 +51,10 @@ fn main() -> Result<(), anyhow::Error> {
         return Ok(());
     }
 
-    // Is there a way to do this without checking twice?
-    let source_data = if options.text.is_empty() {
-        None
-    } else {
-        // Copy the arguments into the target file.
-        let mut iter = options.text.drain(..);
-        let mut data = iter.next().unwrap();
-
-        for arg in iter {
-            data.push(" ");
-            data.push(arg);
-        }
-
-        Some(data)
-    };
-
-    let source = if let Some(source_data) = source_data {
-        Source::Bytes(source_data.into_vec().into())
-    } else {
+    let source = if options.text.is_empty() {
         Source::StdIn
+    } else {
+        Source::Bytes(options.text.join(OsStr::new(" ")).into_vec().into())
     };
 
     let mime_type = if let Some(mime_type) = options.mime_type.take() {


### PR DESCRIPTION
:wave: I'm interested in finishing #65, but I wanted to work my way up to having enough context in the project to contribute a good PR/finish #65. I figured I'd do that by reviewing the codebase for smallish things that could be improved, and this is the first of those. I have a pretty good amount of experience with Rust, but less with Wayland protocols and `wl-clipboard-rs` specifically. Please let me know if this isn't welcome.

---

Collapse two `if` statements into a single one that builds the source value in one step. Also, uses `slice::join` to simplify building the final `OsStr` to be copied.