### PR TITLE
CI: add `libwayland-client0` for `dlopen` jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+      - name: Install native Wayland client support
+        run: sudo apt-get install -y libwayland-client0
+        if: matrix.features == 'dlopen'
+
       - uses: actions/checkout@v6
         with:
           show-progress: false


### PR DESCRIPTION
The `dlopen` feature relies on `libwayland-client0.so` being available to link to at runtime, but recent CI jobs using `dlopen` are failing with the `NoWaylandLib` error. This implies the library is missing. I'm not sure why, but it seems that the CI environment changed at some point and no longer has `libwayland-client0` pre-installed. Maybe it was moving from Ubuntu 22 to 24 in CI (370f971e26)?