### PR TITLE
CI: remove unnecessary `wayland-backend/server_system` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,15 +397,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,9 +919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
 dependencies = [
  "dlib",
- "libc",
  "log",
- "memoffset",
  "once_cell",
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,6 @@ proptest-derive = "0.7"
 
 [features]
 # Link to libwayland-client.so instead of using the Rust implementation.
-native_lib = ["wayland-backend/client_system", "wayland-backend/server_system"]
+native_lib = ["wayland-backend/client_system"]
 
 dlopen = ["native_lib", "wayland-backend/dlopen", "wayland-backend/dlopen"]


### PR DESCRIPTION
This appears to have been a holdover from before the wayland-rs v0.30 update. When using wayland-rs v0.29 the `native_lib` feature enabled the `wayland-client/use_system_lib` and `wayland-server/use_system_lib` features. In 71b6df79ff that switched to `wayland-backend/client_system` and `wayland-backend/server_system`. I'm not sure whether the previous features were required to be enabled together, but it seems that the new set of features can be enabled independently. Removing the server one makes the tests pass in CI and seems correct since `wl-clipboard-rs` should be client-only. The tests use a server, but the Rust one rather than the native one.

I tried to fix this initially in #81, but it turned out that the _client_ library being missing was not the problem. It was the _server_ library being missing that caused the `NoWaylandLib` error in CI. Initially I planned to just install the server library alongside the client in #81, but it didn't seem like the native server was even really necessary. This PR's CI passes, which tells me that's correct. However, I don't know what all the downstream consequences of removing the feature might be. For example, it's possible that a dependent of `wl-clipboard-rs` is relying on the fact that its `dlopen` feature enables `wayland-backend/server_system` and would break as a result of this change. To me, causing that breakage seems like a worthwhile trade-off since that dependent crate is arguably misconfigured.

As I mentioned in #80, I'm fairly new to Wayland APIs and concepts so it's entirely possible I've misunderstood something. If it turns out this feature needs to stay on, then I think installing `libwayland-server0` a la #81 may be a viable alternative.