### PR TITLE
feat: add `watch` library module and `--watch` option to `wl-paste`

### DIFF
--- a/examples/watch.rs
+++ b/examples/watch.rs
@@ -35,7 +35,13 @@ fn main() -> Result<(), Box<dyn Error>> {
                 println!("changed: {} mime type(s) offered", mime_types.len());
                 for mime_type in mime_types {
                     if mime_type.starts_with("text/") {
-                        let mut pipe = offer.receive(&mime_type)?;
+                        let mut pipe = match offer.receive(&mime_type) {
+                            Ok(pipe) => pipe,
+                            Err(e) => {
+                                eprintln!("! Failed to receive {mime_type} data: {e}");
+                                continue;
+                            }
+                        };
                         let mut bytes = Vec::new();
                         pipe.read_to_end(&mut bytes)?;
                         println!("- {mime_type}: {}", String::from_utf8_lossy(&bytes));
@@ -48,6 +54,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     }
 
-    println!("Cancelled.");
+    println!("Stopped.");
     Ok(())
 }

--- a/examples/watch.rs
+++ b/examples/watch.rs
@@ -29,9 +29,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!("Watching the clipboard. Press Enter to stop.");
 
-    while let Some((event, mut offer)) = watcher.next_event()? {
+    while let Some(event) = watcher.next_event()? {
         match event {
-            ClipboardEvent::Changed { mime_types } => {
+            ClipboardEvent::Changed {
+                mime_types,
+                mut offer,
+            } => {
                 println!("changed: {} mime type(s) offered", mime_types.len());
                 for mime_type in mime_types {
                     if mime_type.starts_with("text/") {

--- a/examples/watch.rs
+++ b/examples/watch.rs
@@ -1,0 +1,53 @@
+//! Watches the regular clipboard and prints each selection change until you press Enter.
+//!
+//! Run with `cargo run --example watch`, then copy some text in another application. Press Enter
+//! to stop: that demonstrates cancelling a `Watcher` that is blocked waiting for the next event on
+//! a different thread.
+//!
+//! Note that in `wl-paste` this pattern is not used because it's simpler to just allow a `SIGINT`
+//! or similar to kill the process. In a more complex application this cancellation mechanism should
+//! prove useful.
+
+use std::error::Error;
+use std::io::{self, BufRead, Read};
+use std::thread;
+
+use wl_clipboard_rs::paste::{ClipboardType, Seat};
+use wl_clipboard_rs::watch::{ClipboardEvent, Watcher};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut watcher = Watcher::new(ClipboardType::Regular, Seat::Unspecified)?;
+    let handle = watcher.cancel_handle();
+
+    // The watcher below blocks in poll() waiting for the next selection. Pressing Enter writes to
+    // the cancel pipe from this thread, which wakes that poll and makes next_event() return None.
+    thread::spawn(move || {
+        let mut line = String::new();
+        let _ = io::stdin().lock().read_line(&mut line);
+        handle.cancel();
+    });
+
+    println!("Watching the clipboard. Press Enter to stop.");
+
+    while let Some((event, mut offer)) = watcher.next_event()? {
+        match event {
+            ClipboardEvent::Changed { mime_types } => {
+                println!("changed: {} mime type(s) offered", mime_types.len());
+                for mime_type in mime_types {
+                    if mime_type.starts_with("text/") {
+                        let mut pipe = offer.receive(&mime_type)?;
+                        let mut bytes = Vec::new();
+                        pipe.read_to_end(&mut bytes)?;
+                        println!("- {mime_type}: {}", String::from_utf8_lossy(&bytes));
+                    } else {
+                        println!("- {mime_type}");
+                    }
+                }
+            }
+            ClipboardEvent::Cleared => println!("cleared"),
+        }
+    }
+
+    println!("Cancelled.");
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,33 @@
 //! # }
 //! ```
 //!
+//! Watching the regular clipboard for selection changes and reading each new text selection:
+//! ```no_run
+//! # extern crate wl_clipboard_rs;
+//! # fn foo() -> Result<(), Box<dyn std::error::Error>> {
+//! use std::io::Read;
+//! use wl_clipboard_rs::paste::{ClipboardType, Seat};
+//! use wl_clipboard_rs::watch::{ClipboardEvent, Watcher};
+//!
+//! let mut watcher = Watcher::new(ClipboardType::Regular, Seat::Unspecified)?;
+//! while let Some((event, mut offer)) = watcher.next_event()? {
+//!     match event {
+//!         ClipboardEvent::Changed { mime_types } if mime_types.iter().any(|m| m == "text/plain") => {
+//!             let mut contents = String::new();
+//!             offer.receive("text/plain")?.read_to_string(&mut contents)?;
+//!             println!("Clipboard changed: {contents}");
+//!         }
+//!         ClipboardEvent::Changed { .. } => {}
+//!         ClipboardEvent::Cleared => println!("Clipboard cleared"),
+//!     }
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Obtain a [`watch::CancelHandle`] from [`watch::Watcher::cancel_handle`] to stop a watcher
+//! blocked in [`watch::Watcher::next_event`] from another thread.
+//!
 //! Checking if the "primary" clipboard is supported (note that this might be unnecessary depending
 //! on your crate usage, the regular copying and pasting functions do report if the primary
 //! selection is unsupported when it is requested):
@@ -119,3 +146,4 @@ mod tests;
 pub mod copy;
 pub mod paste;
 pub mod utils;
+pub mod watch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,9 +72,9 @@
 //! use wl_clipboard_rs::watch::{ClipboardEvent, Watcher};
 //!
 //! let mut watcher = Watcher::new(ClipboardType::Regular, Seat::Unspecified)?;
-//! while let Some((event, mut offer)) = watcher.next_event()? {
+//! while let Some(event) = watcher.next_event()? {
 //!     match event {
-//!         ClipboardEvent::Changed { mime_types } if mime_types.iter().any(|m| m == "text/plain") => {
+//!         ClipboardEvent::Changed { mime_types, mut offer } if mime_types.iter().any(|m| m == "text/plain") => {
 //!             let mut contents = String::new();
 //!             offer.receive("text/plain")?.read_to_string(&mut contents)?;
 //!             println!("Clipboard changed: {contents}");

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -408,7 +408,8 @@ pub(crate) fn get_contents_internal(
     Ok((read, mime_type))
 }
 
-/// Selects the best MIME type from `available` according to `requested`.
+/// Selects the best MIME type from `available` according to `requested`. When text types are
+/// available, these will generally be preferred. See [`MimeType`] for details.
 ///
 /// Returns the chosen type, or `None` if none of the available types satisfy the request.
 pub fn select_mime_type(available: Vec<String>, requested: MimeType<'_>) -> Option<String> {

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -431,7 +431,7 @@ pub fn select_mime_type(available: Vec<String>, requested: MimeType<'_>) -> Opti
         MimeType::Any => take!(|x| x == "text/plain;charset=utf-8")
             .or_else(|| take!(|x| x == "UTF8_STRING"))
             .or_else(|| take!(is_text))
-            .or_else(|| take!(|_: &String| true)),
+            .or_else(|| take!(|_| true)),
         MimeType::Text => take!(|x| x == "text/plain;charset=utf-8")
             .or_else(|| take!(|x| x == "UTF8_STRING"))
             .or_else(|| take!(is_text)),
@@ -439,6 +439,6 @@ pub fn select_mime_type(available: Vec<String>, requested: MimeType<'_>) -> Opti
             .or_else(|| take!(|x| x == "text/plain;charset=utf-8"))
             .or_else(|| take!(|x| x == "UTF8_STRING"))
             .or_else(|| take!(is_text)),
-        MimeType::Specific(mime_type) => take!(|x: &String| x == mime_type),
+        MimeType::Specific(mime_type) => take!(|x| x == mime_type),
     }
 }

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -1,4 +1,6 @@
-//! Getting the offered MIME types and the clipboard contents.
+//! Getting the offered MIME types and the clipboard contents once with [`get_contents`].
+//!
+//! To watch for selection changes continuously instead, see [`crate::watch`].
 
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
@@ -151,7 +153,7 @@ impl Dispatch<WlRegistry, GlobalListContents> for State {
 
 impl_dispatch_manager!(State);
 
-impl_dispatch_device!(State, WlSeat, |state: &mut Self, event, seat| {
+impl_dispatch_device!(State, WlSeat, |state: &mut Self, event, seat: &WlSeat| {
     match event {
         Event::DataOffer { id } => {
             let offer = data_control::Offer::from(id);
@@ -384,40 +386,8 @@ pub(crate) fn get_contents_internal(
     let primary = clipboard == ClipboardType::Primary;
     let (mut queue, mut state, offer) = get_offer(primary, seat, socket_name)?;
 
-    let mut mime_types = state.offers.remove(&offer).unwrap();
-
-    macro_rules! take {
-        ($pred:expr) => {
-            'block: {
-                for i in 0..mime_types.len() {
-                    if $pred(&mime_types[i]) {
-                        // We only remove once, so the swap doesn't affect anything.
-                        break 'block Some(mime_types.swap_remove(i));
-                    }
-                }
-                None
-            }
-        };
-    }
-
-    // Find the desired MIME type.
-    let mime_type = match mime_type {
-        MimeType::Any => take!(|x| x == "text/plain;charset=utf-8")
-            .or_else(|| take!(|x| x == "UTF8_STRING"))
-            .or_else(|| take!(is_text))
-            .or_else(|| take!(|_| true)),
-        MimeType::Text => take!(|x| x == "text/plain;charset=utf-8")
-            .or_else(|| take!(|x| x == "UTF8_STRING"))
-            .or_else(|| take!(is_text)),
-        MimeType::TextWithPriority(priority) => take!(|x| x == priority)
-            .or_else(|| take!(|x| x == "text/plain;charset=utf-8"))
-            .or_else(|| take!(|x| x == "UTF8_STRING"))
-            .or_else(|| take!(is_text)),
-        MimeType::Specific(mime_type) => take!(|x| x == mime_type),
-    };
-
-    // Check if a suitable MIME type is copied.
-    let Some(mime_type) = mime_type else {
+    let mime_types = state.offers.remove(&offer).unwrap();
+    let Some(mime_type) = select_mime_type(mime_types, mime_type) else {
         return Err(Error::NoMimeType);
     };
 
@@ -436,4 +406,39 @@ pub(crate) fn get_contents_internal(
         .map_err(Error::WaylandCommunication)?;
 
     Ok((read, mime_type))
+}
+
+/// Selects the best MIME type from `available` according to `requested`.
+///
+/// Returns the chosen type, or `None` if none of the available types satisfy the request.
+pub fn select_mime_type(available: Vec<String>, requested: MimeType<'_>) -> Option<String> {
+    let mut v = available;
+
+    macro_rules! take {
+        ($pred:expr) => {
+            'block: {
+                for i in 0..v.len() {
+                    if $pred(&v[i]) {
+                        break 'block Some(v.swap_remove(i));
+                    }
+                }
+                None
+            }
+        };
+    }
+
+    match requested {
+        MimeType::Any => take!(|x| x == "text/plain;charset=utf-8")
+            .or_else(|| take!(|x| x == "UTF8_STRING"))
+            .or_else(|| take!(is_text))
+            .or_else(|| take!(|_: &String| true)),
+        MimeType::Text => take!(|x| x == "text/plain;charset=utf-8")
+            .or_else(|| take!(|x| x == "UTF8_STRING"))
+            .or_else(|| take!(is_text)),
+        MimeType::TextWithPriority(priority) => take!(|x: &String| x == priority)
+            .or_else(|| take!(|x| x == "text/plain;charset=utf-8"))
+            .or_else(|| take!(|x| x == "UTF8_STRING"))
+            .or_else(|| take!(is_text)),
+        MimeType::Specific(mime_type) => take!(|x: &String| x == mime_type),
+    }
 }

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -419,6 +419,7 @@ pub fn select_mime_type(available: Vec<String>, requested: MimeType<'_>) -> Opti
             'block: {
                 for i in 0..v.len() {
                     if $pred(&v[i]) {
+                        // We only remove once, so the swap doesn't affect anything.
                         break 'block Some(v.swap_remove(i));
                     }
                 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -14,6 +14,7 @@ mod copy;
 mod paste;
 mod state;
 mod utils;
+mod watch;
 
 pub struct TestServer<S: 'static> {
     pub display: Display<S>,

--- a/src/tests/state.rs
+++ b/src/tests/state.rs
@@ -8,10 +8,9 @@
 use std::collections::HashMap;
 use std::io::Write;
 use std::os::fd::AsFd;
+use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering::SeqCst;
-use std::sync::atomic::{AtomicU8, AtomicUsize};
 use std::sync::mpsc::Sender;
-use std::sync::Arc;
 
 use os_pipe::PipeWriter;
 use proptest::prelude::*;
@@ -87,8 +86,6 @@ pub struct State {
     /// All data devices per seat, for propagating selection changes.
     #[proptest(value = "HashMap::new()")]
     pub devices: HashMap<String, Vec<ZwlrDataControlDeviceV1>>,
-    #[proptest(value = "Arc::new(AtomicUsize::new(0))")]
-    pub offer_destroy_request_count: Arc<AtomicUsize>,
 }
 
 server_ignore_global_impl!(State => [ZwlrDataControlManagerV1]);
@@ -309,10 +306,6 @@ impl Dispatch<ZwlrDataControlOfferV1, (String, bool)> for State {
         _dhandle: &wayland_server::DisplayHandle,
         _data_init: &mut wayland_server::DataInit<'_, Self>,
     ) {
-        if let zwlr_data_control_offer_v1::Request::Destroy = request {
-            state.offer_destroy_request_count.fetch_add(1, SeqCst);
-            return;
-        }
         if let zwlr_data_control_offer_v1::Request::Receive { mime_type, fd } = request {
             let info = &state.seats[name];
             let offer_info = if *is_primary {

--- a/src/tests/state.rs
+++ b/src/tests/state.rs
@@ -8,9 +8,10 @@
 use std::collections::HashMap;
 use std::io::Write;
 use std::os::fd::AsFd;
-use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::{AtomicU8, AtomicUsize};
 use std::sync::mpsc::Sender;
+use std::sync::Arc;
 
 use os_pipe::PipeWriter;
 use proptest::prelude::*;
@@ -83,6 +84,11 @@ pub struct State {
     #[proptest(value = "None")]
     pub selection_updated_sender: Option<Sender<Option<Vec<String>>>>,
     pub set_nonblock_on_write_fd: bool,
+    /// All data devices per seat, for propagating selection changes.
+    #[proptest(value = "HashMap::new()")]
+    pub devices: HashMap<String, Vec<ZwlrDataControlDeviceV1>>,
+    #[proptest(value = "Arc::new(AtomicUsize::new(0))")]
+    pub offer_destroy_request_count: Arc<AtomicUsize>,
 }
 
 server_ignore_global_impl!(State => [ZwlrDataControlManagerV1]);
@@ -141,6 +147,11 @@ impl Dispatch<ZwlrDataControlManagerV1, ()> for State {
                 let info = &state.seats[name];
 
                 let data_device = data_init.init(id, (*name).clone());
+                state
+                    .devices
+                    .entry((*name).clone())
+                    .or_default()
+                    .push(data_device.clone());
 
                 let create_offer = |offer_info: &OfferInfo, is_primary: bool| {
                     let offer = client
@@ -184,10 +195,10 @@ impl Dispatch<ZwlrDataControlDeviceV1, String> for State {
     fn request(
         state: &mut Self,
         _client: &wayland_server::Client,
-        _resource: &ZwlrDataControlDeviceV1,
+        resource: &ZwlrDataControlDeviceV1,
         request: <ZwlrDataControlDeviceV1 as Resource>::Request,
         name: &String,
-        _dhandle: &wayland_server::DisplayHandle,
+        dhandle: &wayland_server::DisplayHandle,
         _data_init: &mut wayland_server::DataInit<'_, Self>,
     ) {
         match request {
@@ -207,8 +218,10 @@ impl Dispatch<ZwlrDataControlDeviceV1, String> for State {
                 info.offer = source.map(|source| OfferInfo::Runtime { source });
 
                 if let Some(sender) = &state.selection_updated_sender {
-                    let _ = sender.send(mime_types);
+                    let _ = sender.send(mime_types.clone());
                 }
+
+                propagate_selection(state, dhandle, resource, name, &mime_types, false);
             }
             zwlr_data_control_device_v1::Request::SetPrimarySelection { source } => {
                 let mime_types = source.as_ref().map(|source| state.sources[source].clone());
@@ -226,10 +239,62 @@ impl Dispatch<ZwlrDataControlDeviceV1, String> for State {
                 info.primary_offer = source.map(|source| OfferInfo::Runtime { source });
 
                 if let Some(sender) = &state.selection_updated_sender {
-                    let _ = sender.send(mime_types);
+                    let _ = sender.send(mime_types.clone());
                 }
+
+                propagate_selection(state, dhandle, resource, name, &mime_types, true);
             }
             _ => (),
+        }
+    }
+}
+
+fn propagate_selection(
+    state: &State,
+    dhandle: &wayland_server::DisplayHandle,
+    setter: &ZwlrDataControlDeviceV1,
+    seat_name: &str,
+    mime_types: &Option<Vec<String>>,
+    is_primary: bool,
+) {
+    let Some(devices) = state.devices.get(seat_name) else {
+        return;
+    };
+
+    for device in devices {
+        if device == setter {
+            continue;
+        }
+        let Some(device_client) = device.client() else {
+            continue;
+        };
+
+        match mime_types {
+            None => {
+                if is_primary {
+                    device.primary_selection(None);
+                } else {
+                    device.selection(None);
+                }
+            }
+            Some(types) => {
+                let Ok(offer) = device_client.create_resource::<ZwlrDataControlOfferV1, _, State>(
+                    dhandle,
+                    device.version(),
+                    (seat_name.to_owned(), is_primary),
+                ) else {
+                    continue;
+                };
+                device.data_offer(&offer);
+                for mime_type in types {
+                    offer.offer(mime_type.clone());
+                }
+                if is_primary {
+                    device.primary_selection(Some(&offer));
+                } else {
+                    device.selection(Some(&offer));
+                }
+            }
         }
     }
 }
@@ -244,6 +309,10 @@ impl Dispatch<ZwlrDataControlOfferV1, (String, bool)> for State {
         _dhandle: &wayland_server::DisplayHandle,
         _data_init: &mut wayland_server::DataInit<'_, Self>,
     ) {
+        if let zwlr_data_control_offer_v1::Request::Destroy = request {
+            state.offer_destroy_request_count.fetch_add(1, SeqCst);
+            return;
+        }
         if let zwlr_data_control_offer_v1::Request::Receive { mime_type, fd } = request {
             let info = &state.seats[name];
             let offer_info = if *is_primary {

--- a/src/tests/watch.rs
+++ b/src/tests/watch.rs
@@ -1,0 +1,414 @@
+use std::collections::HashMap;
+use std::io::Read;
+use std::sync::atomic::Ordering::SeqCst;
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use wayland_protocols_wlr::data_control::v1::server::zwlr_data_control_manager_v1::ZwlrDataControlManagerV1;
+
+use crate::copy::{self, MimeSource, Options, ServeRequests, Source};
+use crate::paste::*;
+use crate::tests::state::*;
+use crate::tests::TestServer;
+use crate::watch::{ClipboardEvent, Watcher};
+
+#[test]
+fn watch_initial_changed() {
+    let server = TestServer::new();
+    server
+        .display
+        .handle()
+        .create_global::<State, ZwlrDataControlManagerV1, ()>(2, ());
+
+    let state = State {
+        seats: HashMap::from([(
+            "seat0".into(),
+            SeatInfo {
+                offer: Some(OfferInfo::Buffered {
+                    data: vec![("text/plain".into(), b"hello".to_vec())],
+                }),
+                ..Default::default()
+            },
+        )]),
+        ..Default::default()
+    };
+    state.create_seats(&server);
+
+    let socket_name = server.socket_name().to_owned();
+    server.run(state);
+
+    let mut watcher =
+        Watcher::with_socket(ClipboardType::Regular, Seat::Unspecified, Some(socket_name)).unwrap();
+    let (event, _offer) = watcher.next_event().unwrap().unwrap();
+
+    assert!(
+        matches!(event, ClipboardEvent::Changed { mime_types } if mime_types == ["text/plain"])
+    );
+}
+
+#[test]
+fn watch_initial_cleared() {
+    let server = TestServer::new();
+    server
+        .display
+        .handle()
+        .create_global::<State, ZwlrDataControlManagerV1, ()>(2, ());
+
+    let state = State {
+        seats: HashMap::from([("seat0".into(), SeatInfo::default())]),
+        ..Default::default()
+    };
+    state.create_seats(&server);
+
+    let socket_name = server.socket_name().to_owned();
+    server.run(state);
+
+    let mut watcher =
+        Watcher::with_socket(ClipboardType::Regular, Seat::Unspecified, Some(socket_name)).unwrap();
+    let (event, _offer) = watcher.next_event().unwrap().unwrap();
+
+    assert!(matches!(event, ClipboardEvent::Cleared));
+}
+
+#[test]
+fn watch_receive_contents() {
+    let server = TestServer::new();
+    server
+        .display
+        .handle()
+        .create_global::<State, ZwlrDataControlManagerV1, ()>(2, ());
+
+    let state = State {
+        seats: HashMap::from([(
+            "seat0".into(),
+            SeatInfo {
+                offer: Some(OfferInfo::Buffered {
+                    data: vec![("text/plain".into(), b"world".to_vec())],
+                }),
+                ..Default::default()
+            },
+        )]),
+        ..Default::default()
+    };
+    state.create_seats(&server);
+
+    let socket_name = server.socket_name().to_owned();
+    server.run(state);
+
+    let mut watcher =
+        Watcher::with_socket(ClipboardType::Regular, Seat::Unspecified, Some(socket_name)).unwrap();
+    let (event, mut offer) = watcher.next_event().unwrap().unwrap();
+    assert!(matches!(event, ClipboardEvent::Changed { .. }));
+
+    let mut pipe = offer.receive("text/plain").unwrap();
+    let mut received_data = Vec::new();
+    pipe.read_to_end(&mut received_data).unwrap();
+
+    assert_eq!(received_data, b"world");
+}
+
+#[test]
+fn watch_selection_change() {
+    let server = TestServer::new();
+    server
+        .display
+        .handle()
+        .create_global::<State, ZwlrDataControlManagerV1, ()>(2, ());
+
+    let state = State {
+        seats: HashMap::from([("seat0".into(), SeatInfo::default())]),
+        ..Default::default()
+    };
+    state.create_seats(&server);
+
+    let socket_name = server.socket_name().to_owned();
+    server.run(state);
+
+    let (tx, rx) = mpsc::channel::<ClipboardEvent>();
+    let socket_name2 = socket_name.clone();
+
+    // Watch in a background thread; stop after seeing two events (initial + change).
+    thread::spawn(move || {
+        let mut watcher = Watcher::with_socket(
+            ClipboardType::Regular,
+            Seat::Unspecified,
+            Some(socket_name2),
+        )
+        .unwrap();
+        for _ in 0..2 {
+            let Ok(Some((event, _offer))) = watcher.next_event() else {
+                break;
+            };
+            let _ = tx.send(event);
+        }
+    });
+
+    // First event should be Cleared (empty initial clipboard).
+    let first = rx.recv_timeout(Duration::from_secs(1)).unwrap();
+    assert!(matches!(first, ClipboardEvent::Cleared));
+
+    // Now copy something; the watcher should see a Changed event.
+    let mut opts = Options::new();
+    opts.serve_requests(ServeRequests::Only(0));
+    copy::copy_internal(
+        opts,
+        vec![MimeSource {
+            source: Source::Bytes(b"changed"[..].into()),
+            mime_type: copy::MimeType::Specific("text/plain".into()),
+        }],
+        Some(socket_name),
+    )
+    .unwrap();
+
+    let second = rx.recv_timeout(Duration::from_secs(1)).unwrap();
+    assert!(matches!(
+        second,
+        ClipboardEvent::Changed { ref mime_types } if mime_types.iter().any(|m| m == "text/plain")
+    ));
+}
+
+// Sets the regular clipboard to `payload` via a real copy client that keeps serving paste
+// requests, so the watcher can receive the contents back.
+fn copy_text(socket_name: &std::ffi::OsString, payload: &[u8]) {
+    copy::copy_internal(
+        Options::new(),
+        vec![MimeSource {
+            source: Source::Bytes(payload.into()),
+            mime_type: copy::MimeType::Specific("text/plain".into()),
+        }],
+        Some(socket_name.clone()),
+    )
+    .unwrap();
+}
+
+fn receive_text(offer: &mut crate::watch::Offer<'_>) -> Vec<u8> {
+    let mut pipe = offer.receive("text/plain").unwrap();
+    let mut data = Vec::new();
+    pipe.read_to_end(&mut data).unwrap();
+    data
+}
+
+#[test]
+fn watch_multiple_changes() {
+    let server = TestServer::new();
+    server
+        .display
+        .handle()
+        .create_global::<State, ZwlrDataControlManagerV1, ()>(2, ());
+
+    let state = State {
+        seats: HashMap::from([("seat0".into(), SeatInfo::default())]),
+        ..Default::default()
+    };
+    state.create_seats(&server);
+
+    let socket_name = server.socket_name().to_owned();
+    server.run(state);
+
+    let mut watcher = Watcher::with_socket(
+        ClipboardType::Regular,
+        Seat::Unspecified,
+        Some(socket_name.clone()),
+    )
+    .unwrap();
+
+    // Initial state is the empty clipboard.
+    let (event, offer) = watcher.next_event().unwrap().unwrap();
+    assert!(matches!(event, ClipboardEvent::Cleared));
+    drop(offer);
+
+    // Copy several times in a row, receiving and verifying the contents after each change.
+    for payload in [&b"one"[..], b"two", b"three"] {
+        copy_text(&socket_name, payload);
+
+        let (event, mut offer) = watcher.next_event().unwrap().unwrap();
+        assert!(matches!(event, ClipboardEvent::Changed { .. }));
+        assert_eq!(receive_text(&mut offer), payload);
+    }
+}
+
+#[test]
+fn watch_continues_after_clear() {
+    let server = TestServer::new();
+    server
+        .display
+        .handle()
+        .create_global::<State, ZwlrDataControlManagerV1, ()>(2, ());
+
+    let state = State {
+        seats: HashMap::from([("seat0".into(), SeatInfo::default())]),
+        ..Default::default()
+    };
+    state.create_seats(&server);
+
+    let socket_name = server.socket_name().to_owned();
+    server.run(state);
+
+    let mut watcher = Watcher::with_socket(
+        ClipboardType::Regular,
+        Seat::Unspecified,
+        Some(socket_name.clone()),
+    )
+    .unwrap();
+
+    // Initial empty clipboard.
+    let (event, offer) = watcher.next_event().unwrap().unwrap();
+    assert!(matches!(event, ClipboardEvent::Cleared));
+    drop(offer);
+
+    // A change followed by a successful receive.
+    copy_text(&socket_name, b"before");
+    let (event, mut offer) = watcher.next_event().unwrap().unwrap();
+    assert!(matches!(event, ClipboardEvent::Changed { .. }));
+    assert_eq!(receive_text(&mut offer), b"before");
+    drop(offer);
+
+    // Clearing the clipboard yields a Cleared event. There's nothing to receive, so receive()
+    // reports ClipboardEmpty rather than handing back stale data.
+    copy::clear_internal(
+        copy::ClipboardType::Regular,
+        copy::Seat::All,
+        Some(socket_name.clone()),
+    )
+    .unwrap();
+    let (event, mut offer) = watcher.next_event().unwrap().unwrap();
+    assert!(matches!(event, ClipboardEvent::Cleared));
+    assert!(matches!(
+        offer.receive("text/plain"),
+        Err(Error::ClipboardEmpty)
+    ));
+    drop(offer);
+
+    // A clear in the middle of the stream doesn't stop the watcher: the next change is still
+    // observed and readable.
+    copy_text(&socket_name, b"after");
+    let (event, mut offer) = watcher.next_event().unwrap().unwrap();
+    assert!(matches!(event, ClipboardEvent::Changed { .. }));
+    assert_eq!(receive_text(&mut offer), b"after");
+}
+
+#[test]
+fn watch_rapid_copies_yield_latest_payload() {
+    let server = TestServer::new();
+    server
+        .display
+        .handle()
+        .create_global::<State, ZwlrDataControlManagerV1, ()>(2, ());
+
+    let state = State {
+        seats: HashMap::from([("seat0".into(), SeatInfo::default())]),
+        ..Default::default()
+    };
+    state.create_seats(&server);
+
+    let socket_name = server.socket_name().to_owned();
+    server.run(state);
+
+    let mut watcher = Watcher::with_socket(
+        ClipboardType::Regular,
+        Seat::Unspecified,
+        Some(socket_name.clone()),
+    )
+    .unwrap();
+
+    // Initial empty clipboard.
+    let (event, offer) = watcher.next_event().unwrap().unwrap();
+    assert!(matches!(event, ClipboardEvent::Cleared));
+    drop(offer);
+
+    // Copy several times in a row without draining in between, so the changes queue up.
+    let payloads = [&b"one"[..], b"two", b"three"];
+    for payload in payloads {
+        copy_text(&socket_name, payload);
+    }
+
+    // Each queued change is delivered as its own event, and the last one reads back the latest
+    // payload.
+    for (i, _) in payloads.iter().enumerate() {
+        let (event, mut offer) = watcher.next_event().unwrap().unwrap();
+        assert!(matches!(event, ClipboardEvent::Changed { .. }));
+        if i == payloads.len() - 1 {
+            assert_eq!(receive_text(&mut offer), b"three");
+        }
+    }
+}
+
+#[test]
+fn watch_cancel() {
+    let server = TestServer::new();
+    server
+        .display
+        .handle()
+        .create_global::<State, ZwlrDataControlManagerV1, ()>(2, ());
+
+    let state = State {
+        seats: HashMap::from([("seat0".into(), SeatInfo::default())]),
+        ..Default::default()
+    };
+    state.create_seats(&server);
+
+    let socket_name = server.socket_name().to_owned();
+    server.run(state);
+
+    let mut watcher =
+        Watcher::with_socket(ClipboardType::Regular, Seat::Unspecified, Some(socket_name)).unwrap();
+    let cancel_handle = watcher.cancel_handle();
+    let (tx, rx) = mpsc::channel::<()>();
+
+    let handle = thread::spawn(move || -> Result<(), Error> {
+        // Signal once per event; after the initial event the next call blocks until cancelled.
+        while watcher.next_event()?.is_some() {
+            let _ = tx.send(());
+        }
+        Ok(())
+    });
+
+    // Wait until the watcher has processed the initial event and re-entered the poll.
+    rx.recv_timeout(Duration::from_secs(1)).unwrap();
+
+    cancel_handle.cancel();
+
+    handle.join().unwrap().unwrap();
+}
+
+#[test]
+fn watch_offers_destroyed_on_exit() {
+    let server = TestServer::new();
+    server
+        .display
+        .handle()
+        .create_global::<State, ZwlrDataControlManagerV1, ()>(2, ());
+
+    let state = State {
+        seats: HashMap::from([(
+            "seat0".into(),
+            SeatInfo {
+                offer: Some(OfferInfo::Buffered {
+                    data: vec![("text/plain".into(), b"hello".to_vec())],
+                }),
+                ..Default::default()
+            },
+        )]),
+        ..Default::default()
+    };
+    state.create_seats(&server);
+
+    let socket_name = server.socket_name().to_owned();
+    let destroy_count = Arc::clone(&state.offer_destroy_request_count);
+    let state_mutex = Arc::new(Mutex::new(state));
+    server.run_mutex(Arc::clone(&state_mutex));
+
+    let mut watcher =
+        Watcher::with_socket(ClipboardType::Regular, Seat::Unspecified, Some(socket_name)).unwrap();
+    let event = watcher.next_event().unwrap().unwrap();
+    // Drop the event (releases its borrow), then the watcher, whose Drop destroys the offer.
+    drop(event);
+    drop(watcher);
+
+    // Acquiring the mutex waits for the server thread to finish, which only happens after all
+    // pending client requests (including the offer destroy) have been dispatched.
+    drop(state_mutex.lock().unwrap());
+
+    assert_eq!(destroy_count.load(SeqCst), 1);
+}

--- a/src/tests/watch.rs
+++ b/src/tests/watch.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::io::Read;
-use std::sync::atomic::Ordering::SeqCst;
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::Duration;
 use std::{panic, thread};
@@ -373,45 +372,4 @@ fn watch_cancel() {
     cancel_handle.cancel();
 
     handle.join().unwrap().unwrap();
-}
-
-#[test]
-fn watch_offers_destroyed_on_exit() {
-    let server = TestServer::new();
-    server
-        .display
-        .handle()
-        .create_global::<State, ZwlrDataControlManagerV1, ()>(2, ());
-
-    let state = State {
-        seats: HashMap::from([(
-            "seat0".into(),
-            SeatInfo {
-                offer: Some(OfferInfo::Buffered {
-                    data: vec![("text/plain".into(), b"hello".to_vec())],
-                }),
-                ..Default::default()
-            },
-        )]),
-        ..Default::default()
-    };
-    state.create_seats(&server);
-
-    let socket_name = server.socket_name().to_owned();
-    let destroy_count = Arc::clone(&state.offer_destroy_request_count);
-    let state_mutex = Arc::new(Mutex::new(state));
-    server.run_mutex(Arc::clone(&state_mutex));
-
-    let mut watcher =
-        Watcher::with_socket(ClipboardType::Regular, Seat::Unspecified, Some(socket_name)).unwrap();
-    let event = watcher.next_event().unwrap().unwrap();
-    // Drop the event (releases its borrow), then the watcher, whose Drop destroys the offer.
-    drop(event);
-    drop(watcher);
-
-    // Acquiring the mutex waits for the server thread to finish, which only happens after all
-    // pending client requests (including the offer destroy) have been dispatched.
-    drop(state_mutex.lock().unwrap());
-
-    assert_eq!(destroy_count.load(SeqCst), 1);
 }

--- a/src/tests/watch.rs
+++ b/src/tests/watch.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::io::Read;
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::mpsc;
 use std::time::Duration;
 use std::{panic, thread};
 
@@ -125,31 +125,19 @@ fn watch_selection_change() {
     let socket_name = server.socket_name().to_owned();
     server.run(state);
 
-    let (tx, rx) = mpsc::channel::<Option<Vec<String>>>();
     let socket_name2 = socket_name.clone();
 
-    // Watch in a background thread; stop after seeing two events (initial + change).
-    thread::spawn(move || {
-        let mut watcher = Watcher::with_socket(
-            ClipboardType::Regular,
-            Seat::Unspecified,
-            Some(socket_name2),
-        )
-        .unwrap();
-        for _ in 0..2 {
-            let Ok(Some(event)) = watcher.next_event() else {
-                break;
-            };
-            let _ = tx.send(match event {
-                ClipboardEvent::Changed { mime_types, .. } => Some(mime_types),
-                ClipboardEvent::Cleared => None,
-            });
-        }
-    });
+    let mut watcher = Watcher::with_socket(
+        ClipboardType::Regular,
+        Seat::Unspecified,
+        Some(socket_name2),
+    )
+    .unwrap();
 
     // First event should be Cleared (empty initial clipboard).
-    let first = rx.recv_timeout(Duration::from_secs(1)).unwrap();
-    assert!(first.is_none());
+    let event = watcher.next_event().unwrap().unwrap();
+    assert!(matches!(event, ClipboardEvent::Cleared));
+    drop(event);
 
     // Now copy something; the watcher should see a Changed event.
     let mut opts = Options::new();
@@ -164,8 +152,10 @@ fn watch_selection_change() {
     )
     .unwrap();
 
-    let second = rx.recv_timeout(Duration::from_secs(1)).unwrap().unwrap();
-    assert!(second.iter().any(|m| m == "text/plain"));
+    let event = watcher.next_event().unwrap().unwrap();
+    assert!(
+        matches!(event, ClipboardEvent::Changed { mime_types, .. } if mime_types.iter().any(|m| m == "text/plain"))
+    );
 }
 
 // Sets the regular clipboard to `payload` via a real copy client that keeps serving paste

--- a/src/tests/watch.rs
+++ b/src/tests/watch.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::{mpsc, Arc, Mutex};
-use std::thread;
 use std::time::Duration;
+use std::{panic, thread};
 
 use wayland_protocols_wlr::data_control::v1::server::zwlr_data_control_manager_v1::ZwlrDataControlManagerV1;
 
@@ -40,10 +40,10 @@ fn watch_initial_changed() {
 
     let mut watcher =
         Watcher::with_socket(ClipboardType::Regular, Seat::Unspecified, Some(socket_name)).unwrap();
-    let (event, _offer) = watcher.next_event().unwrap().unwrap();
+    let event = watcher.next_event().unwrap().unwrap();
 
     assert!(
-        matches!(event, ClipboardEvent::Changed { mime_types } if mime_types == ["text/plain"])
+        matches!(event, ClipboardEvent::Changed { mime_types, .. } if mime_types == ["text/plain"])
     );
 }
 
@@ -66,7 +66,7 @@ fn watch_initial_cleared() {
 
     let mut watcher =
         Watcher::with_socket(ClipboardType::Regular, Seat::Unspecified, Some(socket_name)).unwrap();
-    let (event, _offer) = watcher.next_event().unwrap().unwrap();
+    let event = watcher.next_event().unwrap().unwrap();
 
     assert!(matches!(event, ClipboardEvent::Cleared));
 }
@@ -98,8 +98,9 @@ fn watch_receive_contents() {
 
     let mut watcher =
         Watcher::with_socket(ClipboardType::Regular, Seat::Unspecified, Some(socket_name)).unwrap();
-    let (event, mut offer) = watcher.next_event().unwrap().unwrap();
-    assert!(matches!(event, ClipboardEvent::Changed { .. }));
+    let ClipboardEvent::Changed { mut offer, .. } = watcher.next_event().unwrap().unwrap() else {
+        panic!("expected ClipboardEvent::Changed");
+    };
 
     let mut pipe = offer.receive("text/plain").unwrap();
     let mut received_data = Vec::new();
@@ -125,7 +126,7 @@ fn watch_selection_change() {
     let socket_name = server.socket_name().to_owned();
     server.run(state);
 
-    let (tx, rx) = mpsc::channel::<ClipboardEvent>();
+    let (tx, rx) = mpsc::channel::<Option<Vec<String>>>();
     let socket_name2 = socket_name.clone();
 
     // Watch in a background thread; stop after seeing two events (initial + change).
@@ -137,16 +138,19 @@ fn watch_selection_change() {
         )
         .unwrap();
         for _ in 0..2 {
-            let Ok(Some((event, _offer))) = watcher.next_event() else {
+            let Ok(Some(event)) = watcher.next_event() else {
                 break;
             };
-            let _ = tx.send(event);
+            let _ = tx.send(match event {
+                ClipboardEvent::Changed { mime_types, .. } => Some(mime_types),
+                ClipboardEvent::Cleared => None,
+            });
         }
     });
 
     // First event should be Cleared (empty initial clipboard).
     let first = rx.recv_timeout(Duration::from_secs(1)).unwrap();
-    assert!(matches!(first, ClipboardEvent::Cleared));
+    assert!(first.is_none());
 
     // Now copy something; the watcher should see a Changed event.
     let mut opts = Options::new();
@@ -161,11 +165,8 @@ fn watch_selection_change() {
     )
     .unwrap();
 
-    let second = rx.recv_timeout(Duration::from_secs(1)).unwrap();
-    assert!(matches!(
-        second,
-        ClipboardEvent::Changed { ref mime_types } if mime_types.iter().any(|m| m == "text/plain")
-    ));
+    let second = rx.recv_timeout(Duration::from_secs(1)).unwrap().unwrap();
+    assert!(second.iter().any(|m| m == "text/plain"));
 }
 
 // Sets the regular clipboard to `payload` via a real copy client that keeps serving paste
@@ -214,16 +215,19 @@ fn watch_multiple_changes() {
     .unwrap();
 
     // Initial state is the empty clipboard.
-    let (event, offer) = watcher.next_event().unwrap().unwrap();
+    let event = watcher.next_event().unwrap().unwrap();
     assert!(matches!(event, ClipboardEvent::Cleared));
-    drop(offer);
+    drop(event);
 
     // Copy several times in a row, receiving and verifying the contents after each change.
     for payload in [&b"one"[..], b"two", b"three"] {
         copy_text(&socket_name, payload);
 
-        let (event, mut offer) = watcher.next_event().unwrap().unwrap();
-        assert!(matches!(event, ClipboardEvent::Changed { .. }));
+        let ClipboardEvent::Changed { mut offer, .. } = watcher.next_event().unwrap().unwrap()
+        else {
+            panic!("expected ClipboardEvent::Changed");
+        };
+
         assert_eq!(receive_text(&mut offer), payload);
     }
 }
@@ -253,38 +257,35 @@ fn watch_continues_after_clear() {
     .unwrap();
 
     // Initial empty clipboard.
-    let (event, offer) = watcher.next_event().unwrap().unwrap();
+    let event = watcher.next_event().unwrap().unwrap();
     assert!(matches!(event, ClipboardEvent::Cleared));
-    drop(offer);
+    drop(event);
 
     // A change followed by a successful receive.
     copy_text(&socket_name, b"before");
-    let (event, mut offer) = watcher.next_event().unwrap().unwrap();
-    assert!(matches!(event, ClipboardEvent::Changed { .. }));
+    let ClipboardEvent::Changed { mut offer, .. } = watcher.next_event().unwrap().unwrap() else {
+        panic!("expected ClipboardEvent::Changed");
+    };
     assert_eq!(receive_text(&mut offer), b"before");
     drop(offer);
 
-    // Clearing the clipboard yields a Cleared event. There's nothing to receive, so receive()
-    // reports ClipboardEmpty rather than handing back stale data.
+    // Clearing the clipboard yields a Cleared event.
     copy::clear_internal(
         copy::ClipboardType::Regular,
         copy::Seat::All,
         Some(socket_name.clone()),
     )
     .unwrap();
-    let (event, mut offer) = watcher.next_event().unwrap().unwrap();
+    let event = watcher.next_event().unwrap().unwrap();
     assert!(matches!(event, ClipboardEvent::Cleared));
-    assert!(matches!(
-        offer.receive("text/plain"),
-        Err(Error::ClipboardEmpty)
-    ));
-    drop(offer);
+    drop(event);
 
     // A clear in the middle of the stream doesn't stop the watcher: the next change is still
     // observed and readable.
     copy_text(&socket_name, b"after");
-    let (event, mut offer) = watcher.next_event().unwrap().unwrap();
-    assert!(matches!(event, ClipboardEvent::Changed { .. }));
+    let ClipboardEvent::Changed { mut offer, .. } = watcher.next_event().unwrap().unwrap() else {
+        panic!("expected ClipboardEvent::Changed");
+    };
     assert_eq!(receive_text(&mut offer), b"after");
 }
 
@@ -313,9 +314,9 @@ fn watch_rapid_copies_yield_latest_payload() {
     .unwrap();
 
     // Initial empty clipboard.
-    let (event, offer) = watcher.next_event().unwrap().unwrap();
+    let event = watcher.next_event().unwrap().unwrap();
     assert!(matches!(event, ClipboardEvent::Cleared));
-    drop(offer);
+    drop(event);
 
     // Copy several times in a row without draining in between, so the changes queue up.
     let payloads = [&b"one"[..], b"two", b"three"];
@@ -326,8 +327,10 @@ fn watch_rapid_copies_yield_latest_payload() {
     // Each queued change is delivered as its own event, and the last one reads back the latest
     // payload.
     for (i, _) in payloads.iter().enumerate() {
-        let (event, mut offer) = watcher.next_event().unwrap().unwrap();
-        assert!(matches!(event, ClipboardEvent::Changed { .. }));
+        let ClipboardEvent::Changed { mut offer, .. } = watcher.next_event().unwrap().unwrap()
+        else {
+            panic!("expected ClipboardEvent::Changed");
+        };
         if i == payloads.len() - 1 {
             assert_eq!(receive_text(&mut offer), b"three");
         }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,0 +1,353 @@
+//! Watching the clipboard for selection changes with a [`Watcher`].
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::io;
+use std::os::fd::AsFd;
+use std::sync::Arc;
+
+use os_pipe::{pipe, PipeReader, PipeWriter};
+use rustix::event::{PollFd, PollFlags};
+use wayland_backend::client::WaylandError;
+use wayland_client::globals::GlobalListContents;
+use wayland_client::protocol::wl_registry::WlRegistry;
+use wayland_client::protocol::wl_seat::WlSeat;
+use wayland_client::{delegate_dispatch, event_created_child, Dispatch, EventQueue};
+
+use crate::common::{self, initialize};
+use crate::data_control::{self, impl_dispatch_device, impl_dispatch_manager, impl_dispatch_offer};
+use crate::paste::{ClipboardType, Error, Seat};
+
+struct State {
+    common: common::State,
+    // Maps each in-flight offer to its advertised MIME types, populated as Offer events arrive
+    // before the corresponding Selection event links the offer to a seat.
+    offers: HashMap<data_control::Offer, Vec<String>>,
+    got_primary_selection: bool,
+    // Pending selection events to report from the watch loop; (is_primary, seat, offer).
+    selection_events: Vec<(bool, WlSeat, Option<data_control::Offer>)>,
+}
+
+delegate_dispatch!(State: [WlSeat: ()] => common::State);
+
+impl AsMut<common::State> for State {
+    fn as_mut(&mut self) -> &mut common::State {
+        &mut self.common
+    }
+}
+
+impl Dispatch<WlRegistry, GlobalListContents> for State {
+    fn event(
+        _state: &mut Self,
+        _proxy: &WlRegistry,
+        _event: <WlRegistry as wayland_client::Proxy>::Event,
+        _data: &GlobalListContents,
+        _conn: &wayland_client::Connection,
+        _qhandle: &wayland_client::QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl_dispatch_manager!(State);
+
+impl_dispatch_device!(State, WlSeat, |state: &mut Self, event, seat: &WlSeat| {
+    match event {
+        Event::DataOffer { id } => {
+            let offer = data_control::Offer::from(id);
+            state.offers.insert(offer, Vec::new());
+        }
+        Event::Selection { id } => {
+            let offer = id.map(data_control::Offer::from);
+            state.selection_events.push((false, seat.clone(), offer));
+        }
+        Event::Finished => {
+            // Destroy the device stored in the seat as it's no longer valid.
+            let seat_data = state.common.seats.get_mut(seat).unwrap();
+            seat_data.set_device(None);
+        }
+        Event::PrimarySelection { id } => {
+            let offer = id.map(data_control::Offer::from);
+            state.got_primary_selection = true;
+            state.selection_events.push((true, seat.clone(), offer));
+        }
+        _ => (),
+    }
+});
+
+impl_dispatch_offer!(State, |state: &mut Self,
+                             offer: data_control::Offer,
+                             event| {
+    if let Event::Offer { mime_type } = event {
+        state.offers.get_mut(&offer).unwrap().push(mime_type);
+    }
+});
+
+/// Handle used to stop a running [`Watcher`] from another thread.
+///
+/// Obtain one with [`Watcher::cancel_handle`]. Clone-able and safe to send across threads.
+#[derive(Clone)]
+pub struct CancelHandle(Arc<PipeWriter>);
+
+impl CancelHandle {
+    /// Signal the associated [`Watcher`] to stop.
+    ///
+    /// Returns immediately; the watcher exits before its next blocking wait.
+    pub fn cancel(&self) {
+        let _ = rustix::io::write(&*self.0, &[0u8]);
+    }
+}
+
+/// A clipboard selection event reported by [`Watcher::next_event`].
+#[derive(Debug, Clone)]
+pub enum ClipboardEvent {
+    /// The selection changed; `mime_types` lists offered types in protocol order.
+    Changed { mime_types: Vec<String> },
+    /// The selection was cleared.
+    Cleared,
+}
+
+/// Watches the clipboard for selection changes.
+///
+/// Construct one with [`Watcher::new`], then drive it by calling [`Watcher::next_event`] in a
+/// loop. The first call reports the current selection state; subsequent calls block until the
+/// selection changes again.
+///
+/// The caller owns the loop, so you can `break` and `?`-propagate errors. To stop a watcher that
+/// is blocked in [`Watcher::next_event`] on another thread, obtain a [`CancelHandle`] from
+/// [`Watcher::cancel_handle`] and call [`CancelHandle::cancel`].
+pub struct Watcher {
+    queue: EventQueue<State>,
+    state: State,
+    primary: bool,
+    // The single seat whose selections we report, resolved at construction.
+    watched: WlSeat,
+    // Cancellation pipe: the read end is polled in `wait`; the write end is handed out as a
+    // `CancelHandle` and becomes readable once `CancelHandle::cancel` is called.
+    cancel_read: PipeReader,
+    cancel_write: Arc<PipeWriter>,
+}
+
+/// The data offer accompanying a [`ClipboardEvent`], borrowed from its [`Watcher`].
+///
+/// Returned alongside the event by [`Watcher::next_event`]. Holds the live Wayland offer for the
+/// duration of the borrow, so [`Offer::receive`] is only callable before the next
+/// [`Watcher::next_event`] — which is exactly when the offer is valid. A [`ClipboardEvent::Cleared`]
+/// event carries an empty offer, for which [`Offer::receive`] returns [`Error::ClipboardEmpty`].
+pub struct Offer<'a> {
+    watcher: &'a mut Watcher,
+    offer: Option<data_control::Offer>,
+}
+
+impl Watcher {
+    /// Starts watching the clipboard.
+    ///
+    /// Returns an error immediately if there are no seats, the requested seat or protocol is
+    /// missing, or primary selection was requested but is unsupported.
+    pub fn new(clipboard: ClipboardType, seat: Seat<'_>) -> Result<Self, Error> {
+        Self::with_socket(clipboard, seat, None)
+    }
+
+    // The internal constructor accepts the socket name, used for tests.
+    pub(crate) fn with_socket(
+        clipboard: ClipboardType,
+        seat: Seat<'_>,
+        socket_name: Option<OsString>,
+    ) -> Result<Self, Error> {
+        let primary = clipboard == ClipboardType::Primary;
+        let (mut queue, mut common) = initialize(primary, socket_name)?;
+
+        if common.seats.is_empty() {
+            return Err(Error::NoSeats);
+        }
+
+        for (seat, data) in &mut common.seats {
+            let device =
+                common
+                    .clipboard_manager
+                    .get_data_device(seat, &queue.handle(), seat.clone());
+            data.set_device(Some(device));
+        }
+
+        let mut state = State {
+            common,
+            offers: HashMap::new(),
+            got_primary_selection: false,
+            selection_events: Vec::new(),
+        };
+
+        queue
+            .roundtrip(&mut state)
+            .map_err(Error::WaylandCommunication)?;
+
+        if primary && !state.got_primary_selection {
+            return Err(Error::PrimarySelectionUnsupported);
+        }
+
+        let seats = &state.common.seats;
+        let watched = match seat {
+            Seat::Unspecified => seats.keys().next().cloned(),
+            Seat::Specific(name) => seats
+                .iter()
+                .find(|(_, data)| data.name.as_deref() == Some(name))
+                .map(|(seat, _)| seat.clone()),
+        };
+        let Some(watched) = watched else {
+            return Err(Error::SeatNotFound);
+        };
+
+        let (cancel_read, cancel_write) = pipe().map_err(Error::PipeCreation)?;
+
+        Ok(Watcher {
+            queue,
+            state,
+            primary,
+            watched,
+            cancel_read,
+            cancel_write: Arc::new(cancel_write),
+        })
+    }
+
+    /// Returns a handle that stops this watcher when [`CancelHandle::cancel`] is called.
+    ///
+    /// The handle can be cloned and sent to another thread to interrupt a [`Watcher::next_event`]
+    /// call that is blocked waiting for the next selection change.
+    pub fn cancel_handle(&self) -> CancelHandle {
+        CancelHandle(Arc::clone(&self.cancel_write))
+    }
+
+    /// Blocks until the next selection event for the watched clipboard and seat.
+    ///
+    /// On success yields the [`ClipboardEvent`] and an [`Offer`] to read its contents from.
+    /// Returns `Ok(None)` if cancelled via [`CancelHandle::cancel`], or `Err` on a Wayland
+    /// communication failure.
+    pub fn next_event(&mut self) -> Result<Option<(ClipboardEvent, Offer<'_>)>, Error> {
+        while !self.front_matches() {
+            if self.wait()? {
+                return Ok(None);
+            }
+        }
+        Ok(Some(self.take_front_event()))
+    }
+
+    // Discards leading events for other clipboards/seats (destroying their offers), returning
+    // whether a matching event is now at the front of the queue.
+    fn front_matches(&mut self) -> bool {
+        loop {
+            let Some((is_primary, event_seat, _)) = self.state.selection_events.first() else {
+                return false;
+            };
+            if *is_primary == self.primary && *event_seat == self.watched {
+                return true;
+            }
+            let (_, _, offer) = self.state.selection_events.remove(0);
+            if let Some(offer) = offer {
+                self.state.offers.remove(&offer);
+                offer.destroy();
+            }
+        }
+    }
+
+    // Removes the front event, returning its kind and an [`Offer`] to receive from. Only call when
+    // `front_matches` returned `true`.
+    fn take_front_event(&mut self) -> (ClipboardEvent, Offer<'_>) {
+        let (_, _, offer) = self.state.selection_events.remove(0);
+        let mime_types = offer
+            .as_ref()
+            .and_then(|o| self.state.offers.remove(o))
+            .unwrap_or_default();
+        let event = if offer.is_some() {
+            ClipboardEvent::Changed { mime_types }
+        } else {
+            ClipboardEvent::Cleared
+        };
+        (
+            event,
+            Offer {
+                watcher: self,
+                offer,
+            },
+        )
+    }
+
+    // Blocks until more Wayland events arrive (or cancellation). Returns `Ok(true)` if cancelled.
+    fn wait(&mut self) -> Result<bool, Error> {
+        self.queue
+            .flush()
+            .map_err(|e| Error::WaylandCommunication(e.into()))?;
+
+        if let Some(guard) = self.queue.prepare_read() {
+            let wayland_fd = guard.connection_fd();
+            let mut poll_fds = [
+                PollFd::new(&wayland_fd, PollFlags::IN | PollFlags::ERR),
+                PollFd::new(&self.cancel_read, PollFlags::IN),
+            ];
+            loop {
+                match rustix::event::poll(&mut poll_fds, None) {
+                    Ok(_) => break,
+                    Err(rustix::io::Errno::INTR) => continue,
+                    Err(e) => {
+                        return Err(Error::WaylandCommunication(
+                            WaylandError::Io(e.into()).into(),
+                        ))
+                    }
+                }
+            }
+            // Got data on the cancel pipe, bail with `true`.
+            if poll_fds[1].revents().contains(PollFlags::IN) {
+                return Ok(true);
+            }
+            match guard.read() {
+                Ok(_) => {}
+                Err(WaylandError::Io(e)) if e.kind() == io::ErrorKind::WouldBlock => {}
+                Err(e) => return Err(Error::WaylandCommunication(e.into())),
+            }
+        }
+
+        self.queue
+            .dispatch_pending(&mut self.state)
+            .map_err(Error::WaylandCommunication)?;
+        Ok(false)
+    }
+}
+
+impl Drop for Watcher {
+    fn drop(&mut self) {
+        // Destroy any unconsumed queued offers, then drop the seats, which queues destroy requests
+        // for the devices. Flush so the compositor sees them before the socket closes.
+        for offer in self
+            .state
+            .selection_events
+            .drain(..)
+            .filter_map(|(_, _, offer)| offer)
+        {
+            offer.destroy();
+        }
+        self.state.common.seats.clear();
+        let _ = self.queue.flush();
+    }
+}
+
+impl Drop for Offer<'_> {
+    fn drop(&mut self) {
+        if let Some(offer) = self.offer.take() {
+            offer.destroy();
+        }
+    }
+}
+
+impl Offer<'_> {
+    /// Reads the clipboard content of the given MIME type into a pipe.
+    ///
+    /// Returns `Err(Error::ClipboardEmpty)` on a [`ClipboardEvent::Cleared`] event.
+    pub fn receive(&mut self, mime_type: &str) -> Result<PipeReader, Error> {
+        let offer = self.offer.as_ref().ok_or(Error::ClipboardEmpty)?;
+        let (read, write) = pipe().map_err(Error::PipeCreation)?;
+        offer.receive(mime_type.to_string(), write.as_fd());
+        drop(write);
+        self.watcher
+            .queue
+            .roundtrip(&mut self.watcher.state)
+            .map_err(Error::WaylandCommunication)?;
+        Ok(read)
+    }
+}

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -98,10 +98,12 @@ impl CancelHandle {
 }
 
 /// A clipboard selection event reported by [`Watcher::next_event`].
-#[derive(Debug, Clone)]
-pub enum ClipboardEvent {
+pub enum ClipboardEvent<'a> {
     /// The selection changed; `mime_types` lists offered types in protocol order.
-    Changed { mime_types: Vec<String> },
+    Changed {
+        mime_types: Vec<String>,
+        offer: Offer<'a>,
+    },
     /// The selection was cleared.
     Cleared,
 }
@@ -135,7 +137,7 @@ pub struct Watcher {
 /// event carries an empty offer, for which [`Offer::receive`] returns [`Error::ClipboardEmpty`].
 pub struct Offer<'a> {
     watcher: &'a mut Watcher,
-    offer: Option<data_control::Offer>,
+    offer: data_control::Offer,
 }
 
 impl Watcher {
@@ -220,7 +222,7 @@ impl Watcher {
     /// On success yields the [`ClipboardEvent`] and an [`Offer`] to read its contents from.
     /// Returns `Ok(None)` if cancelled via [`CancelHandle::cancel`], or `Err` on a Wayland
     /// communication failure.
-    pub fn next_event(&mut self) -> Result<Option<(ClipboardEvent, Offer<'_>)>, Error> {
+    pub fn next_event<'a>(&'a mut self) -> Result<Option<ClipboardEvent<'a>>, Error> {
         while !self.front_matches() {
             if self.wait()? {
                 return Ok(None);
@@ -249,24 +251,22 @@ impl Watcher {
 
     // Removes the front event, returning its kind and an [`Offer`] to receive from. Only call when
     // `front_matches` returned `true`.
-    fn take_front_event(&mut self) -> (ClipboardEvent, Offer<'_>) {
+    fn take_front_event<'a>(&'a mut self) -> ClipboardEvent<'a> {
         let (_, _, offer) = self.state.selection_events.remove(0);
         let mime_types = offer
             .as_ref()
             .and_then(|o| self.state.offers.remove(o))
             .unwrap_or_default();
-        let event = if offer.is_some() {
-            ClipboardEvent::Changed { mime_types }
-        } else {
-            ClipboardEvent::Cleared
-        };
-        (
-            event,
-            Offer {
-                watcher: self,
-                offer,
+        match offer {
+            Some(offer) => ClipboardEvent::Changed {
+                mime_types,
+                offer: Offer {
+                    watcher: self,
+                    offer,
+                },
             },
-        )
+            None => ClipboardEvent::Cleared,
+        }
     }
 
     // Blocks until more Wayland events arrive (or cancellation). Returns `Ok(true)` if cancelled.
@@ -329,9 +329,7 @@ impl Drop for Watcher {
 
 impl Drop for Offer<'_> {
     fn drop(&mut self) {
-        if let Some(offer) = self.offer.take() {
-            offer.destroy();
-        }
+        self.offer.destroy();
     }
 }
 
@@ -340,9 +338,8 @@ impl Offer<'_> {
     ///
     /// Returns `Err(Error::ClipboardEmpty)` on a [`ClipboardEvent::Cleared`] event.
     pub fn receive(&mut self, mime_type: &str) -> Result<PipeReader, Error> {
-        let offer = self.offer.as_ref().ok_or(Error::ClipboardEmpty)?;
         let (read, write) = pipe().map_err(Error::PipeCreation)?;
-        offer.receive(mime_type.to_string(), write.as_fd());
+        self.offer.receive(mime_type.to_string(), write.as_fd());
         drop(write);
         self.watcher
             .queue

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -310,23 +310,6 @@ impl Watcher {
     }
 }
 
-impl Drop for Watcher {
-    fn drop(&mut self) {
-        // Destroy any unconsumed queued offers, then drop the seats, which queues destroy requests
-        // for the devices. Flush so the compositor sees them before the socket closes.
-        for offer in self
-            .state
-            .selection_events
-            .drain(..)
-            .filter_map(|(_, _, offer)| offer)
-        {
-            offer.destroy();
-        }
-        self.state.common.seats.clear();
-        let _ = self.queue.flush();
-    }
-}
-
 impl Drop for Offer<'_> {
     fn drop(&mut self) {
         self.offer.destroy();

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -326,8 +326,8 @@ impl Offer<'_> {
         drop(write);
         self.watcher
             .queue
-            .roundtrip(&mut self.watcher.state)
-            .map_err(Error::WaylandCommunication)?;
+            .flush()
+            .map_err(|e| Error::WaylandCommunication(e.into()))?;
         Ok(read)
     }
 }

--- a/wl-clipboard-rs-tools/src/bin/wl-paste.rs
+++ b/wl-clipboard-rs-tools/src/bin/wl-paste.rs
@@ -77,7 +77,7 @@ fn main() -> Result<(), anyhow::Error> {
     };
 
     if options.watch {
-        return watch_mode(primary, seat, mime_type_selector, &options.watch_command);
+        return watch(primary, seat, mime_type_selector, &options.watch_command);
     }
 
     let (mut read, mime_type) = get_contents(primary, seat, mime_type_selector)?;
@@ -106,7 +106,7 @@ const CLIPBOARD_STATE_SENSITIVE: &str = "sensitive";
 const CLIPBOARD_STATE_NIL: &str = "nil";
 const MIME_TYPE_PASSWORD_MANAGER_HINT: &str = "x-kde-passwordManagerHint";
 
-fn watch_mode(
+fn watch(
     clipboard: ClipboardType,
     seat: Seat<'_>,
     mime_type_selector: MimeType<'_>,

--- a/wl-clipboard-rs-tools/src/bin/wl-paste.rs
+++ b/wl-clipboard-rs-tools/src/bin/wl-paste.rs
@@ -139,7 +139,7 @@ fn watch_mode(
 
         match offer.receive(&selected) {
             Ok(pipe) => run_watch_cmd(cmd, Stdio::from(pipe), clipboard_state),
-            Err(e) => eprintln!("wl-paste: {e}"),
+            Err(e) => eprintln!("wl-paste: failed to receive clipboard contents: {e}"),
         }
     }
     Ok(())

--- a/wl-clipboard-rs-tools/src/bin/wl-paste.rs
+++ b/wl-clipboard-rs-tools/src/bin/wl-paste.rs
@@ -1,6 +1,5 @@
 #![deny(unsafe_code)]
 
-use std::ffi::OsStr;
 use std::fs::read_link;
 use std::io::{stdout, Read, Write};
 use std::process::{Command, Stdio};
@@ -102,34 +101,10 @@ fn main() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-enum ClipboardState {
-    Data,
-    Sensitive,
-    Nil,
-}
-
-impl ClipboardState {
-    fn for_mime_types(mime_types: &[String]) -> Self {
-        if mime_types
-            .iter()
-            .any(|mt| mt == "x-kde-passwordManagerHint")
-        {
-            Self::Sensitive
-        } else {
-            Self::Data
-        }
-    }
-}
-
-impl AsRef<OsStr> for ClipboardState {
-    fn as_ref(&self) -> &OsStr {
-        OsStr::new(match self {
-            Self::Data => "data",
-            Self::Sensitive => "sensitive",
-            Self::Nil => "nil",
-        })
-    }
-}
+const CLIPBOARD_STATE_DATA: &str = "data";
+const CLIPBOARD_STATE_SENSITIVE: &str = "sensitive";
+const CLIPBOARD_STATE_NIL: &str = "nil";
+const MIME_TYPE_PASSWORD_MANAGER_HINT: &str = "x-kde-passwordManagerHint";
 
 fn watch_mode(
     clipboard: ClipboardType,
@@ -145,11 +120,18 @@ fn watch_mode(
         };
 
         let Some(mime_types) = mime_types else {
-            run_watch_cmd(cmd, Stdio::null(), ClipboardState::Nil);
+            run_watch_cmd(cmd, Stdio::null(), CLIPBOARD_STATE_NIL);
             continue;
         };
 
-        let clipboard_state = ClipboardState::for_mime_types(&mime_types);
+        let clipboard_state = if mime_types
+            .iter()
+            .any(|mt| mt == MIME_TYPE_PASSWORD_MANAGER_HINT)
+        {
+            CLIPBOARD_STATE_SENSITIVE
+        } else {
+            CLIPBOARD_STATE_DATA
+        };
 
         let Some(selected) = select_mime_type(mime_types, mime_type_selector) else {
             continue;
@@ -163,7 +145,7 @@ fn watch_mode(
     Ok(())
 }
 
-fn run_watch_cmd(cmd: &[String], stdin: Stdio, clipboard_state: ClipboardState) {
+fn run_watch_cmd(cmd: &[String], stdin: Stdio, clipboard_state: &str) {
     match Command::new(&cmd[0])
         .args(&cmd[1..])
         .stdin(stdin)

--- a/wl-clipboard-rs-tools/src/bin/wl-paste.rs
+++ b/wl-clipboard-rs-tools/src/bin/wl-paste.rs
@@ -59,8 +59,8 @@ fn main() -> Result<(), anyhow::Error> {
         None
     };
 
-    // Build the MimeType selector (shared by both watch and single-paste paths).
-    let mime_type_selector = match options.mime_type {
+    // Do some smart MIME type selection.
+    let mime_type = match options.mime_type {
         Some(ref mime_type) if mime_type == "text" => MimeType::Text,
         Some(ref mime_type) => MimeType::Specific(mime_type),
         None => {
@@ -77,10 +77,10 @@ fn main() -> Result<(), anyhow::Error> {
     };
 
     if options.watch {
-        return watch(primary, seat, mime_type_selector, &options.watch_command);
+        return watch(primary, seat, mime_type, &options.watch_command);
     }
 
-    let (mut read, mime_type) = get_contents(primary, seat, mime_type_selector)?;
+    let (mut read, mime_type) = get_contents(primary, seat, mime_type)?;
 
     // Read the contents.
     let mut contents = vec![];

--- a/wl-clipboard-rs-tools/src/bin/wl-paste.rs
+++ b/wl-clipboard-rs-tools/src/bin/wl-paste.rs
@@ -113,33 +113,33 @@ fn watch_mode(
     cmd: &[String],
 ) -> Result<(), anyhow::Error> {
     let mut watcher = Watcher::new(clipboard, seat)?;
-    while let Some((event, mut offer)) = watcher.next_event()? {
-        let mime_types = match event {
-            ClipboardEvent::Cleared => None,
-            ClipboardEvent::Changed { mime_types } => Some(mime_types),
-        };
+    while let Some(event) = watcher.next_event()? {
+        match event {
+            ClipboardEvent::Cleared => {
+                run_watch_cmd(cmd, Stdio::null(), CLIPBOARD_STATE_NIL);
+            }
+            ClipboardEvent::Changed {
+                mime_types,
+                mut offer,
+            } => {
+                let clipboard_state = if mime_types
+                    .iter()
+                    .any(|mt| mt == MIME_TYPE_PASSWORD_MANAGER_HINT)
+                {
+                    CLIPBOARD_STATE_SENSITIVE
+                } else {
+                    CLIPBOARD_STATE_DATA
+                };
 
-        let Some(mime_types) = mime_types else {
-            run_watch_cmd(cmd, Stdio::null(), CLIPBOARD_STATE_NIL);
-            continue;
-        };
+                let Some(selected) = select_mime_type(mime_types, mime_type_selector) else {
+                    continue;
+                };
 
-        let clipboard_state = if mime_types
-            .iter()
-            .any(|mt| mt == MIME_TYPE_PASSWORD_MANAGER_HINT)
-        {
-            CLIPBOARD_STATE_SENSITIVE
-        } else {
-            CLIPBOARD_STATE_DATA
-        };
-
-        let Some(selected) = select_mime_type(mime_types, mime_type_selector) else {
-            continue;
-        };
-
-        match offer.receive(&selected) {
-            Ok(pipe) => run_watch_cmd(cmd, Stdio::from(pipe), clipboard_state),
-            Err(e) => eprintln!("wl-paste: failed to receive clipboard contents: {e}"),
+                match offer.receive(&selected) {
+                    Ok(pipe) => run_watch_cmd(cmd, Stdio::from(pipe), clipboard_state),
+                    Err(e) => eprintln!("wl-paste: failed to receive clipboard contents: {e}"),
+                }
+            }
         }
     }
     Ok(())

--- a/wl-clipboard-rs-tools/src/bin/wl-paste.rs
+++ b/wl-clipboard-rs-tools/src/bin/wl-paste.rs
@@ -1,7 +1,9 @@
 #![deny(unsafe_code)]
 
+use std::ffi::OsStr;
 use std::fs::read_link;
 use std::io::{stdout, Read, Write};
+use std::process::{Command, Stdio};
 
 use anyhow::Context;
 use clap::Parser;
@@ -10,6 +12,7 @@ use log::trace;
 use mime_guess::Mime;
 use wl_clipboard_rs::paste::*;
 use wl_clipboard_rs::utils::is_text;
+use wl_clipboard_rs::watch::{ClipboardEvent, Watcher};
 use wl_clipboard_rs_tools::wl_paste::Options;
 
 fn infer_mime_type() -> Option<Mime> {
@@ -50,8 +53,6 @@ fn main() -> Result<(), anyhow::Error> {
         return Ok(());
     }
 
-    // Otherwise, get the clipboard contents.
-
     // No MIME type specified—try inferring one from the output file extension (if any).
     let inferred = if options.mime_type.is_none() {
         infer_mime_type()
@@ -59,8 +60,8 @@ fn main() -> Result<(), anyhow::Error> {
         None
     };
 
-    // Do some smart MIME type selection.
-    let mime_type = match options.mime_type {
+    // Build the MimeType selector (shared by both watch and single-paste paths).
+    let mime_type_selector = match options.mime_type {
         Some(ref mime_type) if mime_type == "text" => MimeType::Text,
         Some(ref mime_type) => MimeType::Specific(mime_type),
         None => {
@@ -76,7 +77,11 @@ fn main() -> Result<(), anyhow::Error> {
         }
     };
 
-    let (mut read, mime_type) = get_contents(primary, seat, mime_type)?;
+    if options.watch {
+        return watch_mode(primary, seat, mime_type_selector, &options.watch_command);
+    }
+
+    let (mut read, mime_type) = get_contents(primary, seat, mime_type_selector)?;
 
     // Read the contents.
     let mut contents = vec![];
@@ -95,4 +100,79 @@ fn main() -> Result<(), anyhow::Error> {
         .context("Couldn't write contents to stdout")?;
 
     Ok(())
+}
+
+enum ClipboardState {
+    Data,
+    Sensitive,
+    Nil,
+}
+
+impl ClipboardState {
+    fn for_mime_types(mime_types: &[String]) -> Self {
+        if mime_types
+            .iter()
+            .any(|mt| mt == "x-kde-passwordManagerHint")
+        {
+            Self::Sensitive
+        } else {
+            Self::Data
+        }
+    }
+}
+
+impl AsRef<OsStr> for ClipboardState {
+    fn as_ref(&self) -> &OsStr {
+        OsStr::new(match self {
+            Self::Data => "data",
+            Self::Sensitive => "sensitive",
+            Self::Nil => "nil",
+        })
+    }
+}
+
+fn watch_mode(
+    clipboard: ClipboardType,
+    seat: Seat<'_>,
+    mime_type_selector: MimeType<'_>,
+    cmd: &[String],
+) -> Result<(), anyhow::Error> {
+    let mut watcher = Watcher::new(clipboard, seat)?;
+    while let Some((event, mut offer)) = watcher.next_event()? {
+        let mime_types = match event {
+            ClipboardEvent::Cleared => None,
+            ClipboardEvent::Changed { mime_types } => Some(mime_types),
+        };
+
+        let Some(mime_types) = mime_types else {
+            run_watch_cmd(cmd, Stdio::null(), ClipboardState::Nil);
+            continue;
+        };
+
+        let clipboard_state = ClipboardState::for_mime_types(&mime_types);
+
+        let Some(selected) = select_mime_type(mime_types, mime_type_selector) else {
+            continue;
+        };
+
+        match offer.receive(&selected) {
+            Ok(pipe) => run_watch_cmd(cmd, Stdio::from(pipe), clipboard_state),
+            Err(e) => eprintln!("wl-paste: {e}"),
+        }
+    }
+    Ok(())
+}
+
+fn run_watch_cmd(cmd: &[String], stdin: Stdio, clipboard_state: ClipboardState) {
+    match Command::new(&cmd[0])
+        .args(&cmd[1..])
+        .stdin(stdin)
+        .env("CLIPBOARD_STATE", clipboard_state)
+        .spawn()
+    {
+        Ok(mut child) => {
+            let _ = child.wait();
+        }
+        Err(e) => eprintln!("wl-paste: failed to spawn {}: {e}", cmd[0]),
+    }
 }

--- a/wl-clipboard-rs-tools/src/wl_paste.rs
+++ b/wl-clipboard-rs-tools/src/wl_paste.rs
@@ -47,4 +47,22 @@ pub struct Options {
     /// Enable verbose logging
     #[arg(long, short, action = clap::ArgAction::Count)]
     pub verbose: u8,
+
+    /// Run a command each time the selection changes
+    ///
+    /// COMMAND and its arguments must follow all other wl-paste options.
+    /// The command is invoked with the new clipboard contents on stdin.
+    /// CLIPBOARD_STATE env is set to "data", "sensitive", or "nil" (cleared).
+    #[arg(long, short = 'w', conflicts_with = "list_types")]
+    pub watch: bool,
+
+    /// The command (and arguments) to run in watch mode
+    #[arg(
+        requires = "watch",
+        required_if_eq("watch", "true"),
+        allow_hyphen_values = true,
+        num_args = 1..,
+        value_name = "COMMAND"
+    )]
+    pub watch_command: Vec<String>,
 }


### PR DESCRIPTION
Another attempt at fixing #5. The previous attempt, #65, got hung up on tests.

### Library

This version introduces a `watch` module with a `Watcher` struct. `Watcher::next_event` blocks until the next event comes in over the socket:

```rust
let mut watcher = Watcher::new(ClipboardType::Regular, Seat::Unspecified)?;
while let Some(event) = watcher.next_event()? {
    match event {
        ClipboardEvent::Changed { mime_types, mut offer } if mime_types.iter().any(|m| m == "text/plain") => {
            let mut contents = String::new();
            offer.receive("text/plain")?.read_to_string(&mut contents)?;
            println!("Clipboard changed: {contents}");
        }
        ClipboardEvent::Changed { .. } => {}
        ClipboardEvent::Cleared => println!("Clipboard cleared"),
    }
}
```

If you need to support cancelling the watch, get a cancel handle from the `Watcher`:

```rust
let handle = watcher.cancel_handle();

thread::spawn(move || {
    block_on_cancel_condition();
    handle.cancel();
});
```

### `wl-paste`

Adds a `--watch` option that should behave the same way the C version of `wl-paste` does:

```
# first, echos the current clipboard (CLIPBOARD_STATE=data)
# then I copied a new password from 1Password (CLIPBOARD_STATE=sensitive)
# then I ran `wl-copy -c` to clear the clipboard (CLIPBOARD_STATE=nil)
> wl-paste --watch sh -c 'echo $CLIPBOARD_STATE; cat'
data
cargo doc --no-deps -p wl-clipboard-rs
sensitive
gU6HWkswwgJ4AMAhW2FM
nil
```

### Open Questions/Issues

1. ~Do you want an example program? I added one but you didn't have any others so maybe you see the tools crate as sufficient for that.~ Example program is fine.
2. In #65 you said you wanted a test that verified that it recovers after an error. Can you be more specific about what you're looking for with that? I didn't see a clear way to trigger an error within the `TestServer` and wasn't really sure how it should behave given a Wayland error anyway. Right now it's up to the caller of `next_event`.
3. Do you prefer the `mpsc::channel` approach from #65?