### PR TITLE
Change license format to 'MIT OR Apache-2.0'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["wl-clipboard-rs-tools"]
 version = "0.9.3" # remember to update html_root_url
 authors = ["Ivan Molodetskikh <yalterz@gmail.com>"]
 edition = "2021"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/YaLTeR/wl-clipboard-rs"
 keywords = ["wayland", "clipboard"]
 


### PR DESCRIPTION
This is the valid SPDX spec, as per https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields and https://spdx.github.io/spdx-spec/v2.2/SPDX-license-expressions/

Fixing this allows the package to pass some license requirements automated tests that now choke on this.